### PR TITLE
Use Matlab_ROOT_DIR as opposed to MATLAB_ROOT

### DIFF
--- a/SuperBuild.cmake
+++ b/SuperBuild.cmake
@@ -41,7 +41,7 @@ set_property(CACHE EXTERNAL_PROJECT_BUILD_TYPE PROPERTY
 STRINGS "Debug" "Release" "MinSizeRel" "RelWithDebInfo")
 
 
-set(MATLAB_ROOT CACHE PATH "Path to Matlab root directory")
+set(Matlab_ROOT_DIR CACHE PATH "Path to Matlab root directory")
 
 option(USE_SYSTEM_Boost "Build using an external version of Boost" OFF)
 option(USE_SYSTEM_STIR "Build using an external version of STIR" OFF)

--- a/SuperBuild/External_SIRF.cmake
+++ b/SuperBuild/External_SIRF.cmake
@@ -25,7 +25,7 @@ set(proj SIRF)
 # Set dependency list
 set(${proj}_DEPENDENCIES "STIR;Boost;HDF5;ISMRMRD;FFTW3;SWIG")
 
-message(STATUS "MATLAB_ROOT=" ${MATLAB_ROOT})
+message(STATUS "Matlab_ROOT_DIR=" ${Matlab_ROOT_DIR})
 message(STATUS "STIR_DIR=" ${STIR_DIR})
 
 # Include dependent projects if any
@@ -70,7 +70,8 @@ if(NOT ( DEFINED "USE_SYSTEM_${externalProjName}" AND "${USE_SYSTEM_${externalPr
         -DCMAKE_INSTALL_PREFIX=${SIRF_Install_Dir}
         -DBOOST_INCLUDEDIR=${BOOST_ROOT}/include/
         -DBOOST_LIBRARYDIR=${BOOST_LIBRARY_DIR}
-        -DMATLAB_ROOT=${MATLAB_ROOT}
+        -DMatlab_ROOT_DIR=${Matlab_ROOT_DIR}
+        -DMATLAB_ROOT=${Matlab_ROOT_DIR} # pass this for compatibility with old SIRF
         -DSTIR_DIR=${STIR_DIR}
         -DHDF5_ROOT=${HDF5_ROOT}
         -DHDF5_INCLUDE_DIRS=${HDF5_INCLUDE_DIRS}


### PR DESCRIPTION
WARNING: This breaks backwards compatibility.

Matlab_ROOT_DIR is the variable used by CMake's FindMatlab.cmake so is what we should use as well.

Currently we use this to set both variables for SIRF (as SIRF 0.9.0 used MATLAB_ROOT).