### PR TITLE
DEVEL_BUILD and BUILD_GADGETRON_NATIVE_PYTHON_SUPPORT

### DIFF
--- a/SuperBuild/External_Gadgetron.cmake
+++ b/SuperBuild/External_Gadgetron.cmake
@@ -53,8 +53,9 @@ if (MKL_FOUND)
   endif ()
 endif ()
 
-  option(BUILD_GADGETRON_NATIVE_PYTHON_SUPPORT
-    "Build Gadgetron Python gadgets (not required for SIRF)" OFF)
+  #option(BUILD_GADGETRON_NATIVE_PYTHON_SUPPORT
+  #  "Build Gadgetron Python gadgets (not required for SIRF)" OFF)
+  set(BUILD_GADGETRON_NATIVE_PYTHON_SUPPORT OFF) # <-Disabled for v1.0
   option(BUILD_GADGETRON_NATIVE_MATLAB_SUPPORT
     "Build Gadgetron MATLAB gadgets (not required for SIRF)" OFF)
 

--- a/version_config.cmake
+++ b/version_config.cmake
@@ -78,6 +78,7 @@ set(ITK_URL https://itk.org/ITK.git)
 set(ITK_TAG v4.13.0)
 
 option (DEVEL_BUILD "Developer Build" OFF)
+mark_as_advanced(DEVEL_BUILD)
 
 #Set the default versions for SIRF, STIR, Gadgetron and ISMRMRD
 # with devel build it uses latest version of upstream packages


### PR DESCRIPTION
Set `DEVEL_BUILD` as an advanced variable. 
Changed `BUILD_GADGETRON_NATIVE_PYTHON_SUPPORT` from `option` to `set`.