### PR TITLE
Travis OSX

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,38 +11,57 @@ language: cpp
 
 # Environment variables
 # Note: On trusty we need to build Armadillo ourselves (the system version is too old)
-# Note: on OSX we don't seem to be able to use the system boost 1.65.1 due to a Mac-specific bug.
 # Note: altering the matrix here will cause re-building of caches,
 # so try to keep this concise to avoid need to update
 matrix:
  include:
- #- os: linux
- #  python: 3
- #  env: EXTRA_BUILD_FLAGS="-DUSE_SYSTEM_Boost=ON -DUSE_SYSTEM_HDF5=ON -DUSE_SYSTEM_FFTW3=ON" CC=gcc-5 CXX=g++-5 PYMVER=3
- #- os: linux
- #  python: 2.7
- #  env: EXTRA_BUILD_FLAGS="-DUSE_SYSTEM_Boost=ON -DUSE_SYSTEM_SWIG=ON -DUSE_SYSTEM_HDF5=ON -DUSE_SYSTEM_FFTW3=ON -DBUILD_siemens_to_ismrmrd=ON" CC=gcc-5 CXX=g++-5 PYMVER=2
- #- os: linux
- #  python: 3
- #  env: EXTRA_BUILD_FLAGS="-DUSE_SYSTEM_Boost=ON -DUSE_SYSTEM_HDF5=OFF -DUSE_SYSTEM_FFTW3=OFF -DDEVEL_BUILD=ON -DBUILD_siemens_to_ismrmrd=ON" CC=gcc-5 CXX=g++-5 PYMVER=3
- #- os: linux
- #  python: 2.7
- #  env: EXTRA_BUILD_FLAGS="-DUSE_SYSTEM_Boost=ON -DUSE_SYSTEM_SWIG=OFF -DUSE_SYSTEM_HDF5=OFF -DUSE_SYSTEM_FFTW3=OFF -DDEVEL_BUILD=ON" CC=gcc-5 CXX=g++-5 PYMVER=2
- #- os: linux
- #  python: 3
- #  env: EXTRA_BUILD_FLAGS="-DUSE_SYSTEM_Boost=ON -DUSE_SYSTEM_HDF5=ON -DUSE_SYSTEM_FFTW3=ON -DUSE_ITK=ON" CC=gcc-5 CXX=g++-5 PYMVER=3
+ # linux g{cc,++}-5 py{27,3}
+ - os: linux
+   python: 3
+   # +fftw3 +hdf5
+   env: EXTRA_BUILD_FLAGS="-DUSE_SYSTEM_FFTW3=ON -DUSE_SYSTEM_HDF5=ON" CC=gcc-5 CXX=g++-5 PYMVER=3
+ - os: linux
+   python: 2.7
+   # +fftw3 +hdf5 +siemens_to_ismrmrd +swig
+   env: EXTRA_BUILD_FLAGS="-DUSE_SYSTEM_FFTW3=ON -DUSE_SYSTEM_HDF5=ON -DBUILD_siemens_to_ismrmrd=ON -DUSE_SYSTEM_SWIG=ON" CC=gcc-5 CXX=g++-5 PYMVER=2
+ - os: linux
+   python: 3
+   # +DEVEL -hdf5 -fftw3 +siemens_to_ismrmrd
+   env: EXTRA_BUILD_FLAGS="-DDEVEL_BUILD=ON -DUSE_SYSTEM_HDF5=OFF -DUSE_SYSTEM_FFTW3=OFF -DBUILD_siemens_to_ismrmrd=ON" CC=gcc-5 CXX=g++-5 PYMVER=3
+ - os: linux
+   python: 2.7
+   # +DEVEL -fftw3 -hdf5 -swig
+   env: EXTRA_BUILD_FLAGS="-DDEVEL_BUILD=ON -DUSE_SYSTEM_FFTW3=OFF -DUSE_SYSTEM_HDF5=OFF -DUSE_SYSTEM_SWIG=OFF" CC=gcc-5 CXX=g++-5 PYMVER=2
+ # osx g{cc,++} py{27,36}
  - os: osx
-   language: generic
-   env: EXTRA_BUILD_FLAGS="-DSHARED_LIBS_ABS_PATH=ON -DUSE_SYSTEM_Boost=ON -DUSE_SYSTEM_HDF5=OFF -DUSE_SYSTEM_SWIG=OFF" CC=gcc CXX=g++ PYMVER=2
+   python: 2.7
+   # -hdf5 -swig
+   env: EXTRA_BUILD_FLAGS="-DUSE_SYSTEM_HDF5=OFF -DUSE_SYSTEM_SWIG=OFF" CC=gcc CXX=g++ PYMVER=2
  - os: osx
-   language: generic
-   env: EXTRA_BUILD_FLAGS="-DSHARED_LIBS_ABS_PATH=ON -DUSE_SYSTEM_Boost=ON -DUSE_SYSTEM_HDF5=OFF -DUSE_SYSTEM_SWIG=OFF" CC=gcc CXX=g++ PYMVER=3
+   # -hdf5 -swig
+   python: 3
+   env: EXTRA_BUILD_FLAGS="-DUSE_SYSTEM_HDF5=OFF -DUSE_SYSTEM_SWIG=OFF" CC=gcc CXX=g++ PYMVER=3
  - os: osx
-   language: generic
-   env: EXTRA_BUILD_FLAGS="-DSHARED_LIBS_ABS_PATH=OFF -DUSE_SYSTEM_Boost=ON -DUSE_SYSTEM_HDF5=OFF -DUSE_SYSTEM_SWIG=OFF" CC=gcc CXX=g++ PYMVER=3
+   python: 2.7
+   # +DEVEL -hdf5 +swig
+   env: EXTRA_BUILD_FLAGS="-DDEVEL_BUILD=ON -DUSE_SYSTEM_HDF5=OFF -DUSE_SYSTEM_SWIG=ON" CC=gcc CXX=g++ PYMVER=2
+ - os: osx
+   python: 2.7
+   # +DEVEL -fftw3 -hdf5 +swig
+   env: EXTRA_BUILD_FLAGS="-DDEVEL_BUILD=ON -DUSE_SYSTEM_FFTW3=OFF -DUSE_SYSTEM_HDF5=OFF -DUSE_SYSTEM_SWIG=ON" CC=gcc CXX=g++ PYMVER=2
+ #  itk
+ - os: linux
+   python: 3
+   # +itk +fftw3 +hdf5
+   env: EXTRA_BUILD_FLAGS="-DUSE_ITK=ON -DUSE_SYSTEM_FFTW3=ON -DUSE_SYSTEM_HDF5=ON" CC=gcc-5 CXX=g++-5 PYMVER=3
+ - os: osx
+   python: 2.7
+   # +itk -hdf5 +swig
+   env: EXTRA_BUILD_FLAGS="-DUSE_ITK=ON -DUSE_SYSTEM_HDF5=OFF -DUSE_SYSTEM_SWIG=ON" CC=gcc CXX=g++ PYMVER=2
+
 env:
  global:
-  - BUILD_FLAGS="-DCMAKE_BUILD_TYPE=Release"
+  - BUILD_FLAGS="-DCMAKE_BUILD_TYPE=Release -DUSE_SYSTEM_Boost=ON"
   # don't use too many threads - may crash
   - MAKEFLAGS="-j 2"
 
@@ -90,25 +109,26 @@ before_install:
  - pushd ~/.local/bin
  - |
     if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
+      export BUILD_FLAGS="$BUILD_FLAGS -DSHARED_LIBS_ABS_PATH=ON"
       if [ $PYMVER == 2 ]; then
-        alias python$PYMVER=/System/Library/Frameworks/Python.framework/Versions/2.7/bin/python2.7
-        export BUILD_FLAGS="$BUILD_FLAGS -DPYTHON_EXECUTABLE=/System/Library/Frameworks/Python.framework/Versions/2.7/bin/python2.7"
-        export BUILD_FLAGS="$BUILD_FLAGS -DPYTHON_LIBRARY=/System/Library/Frameworks/Python.framework/Versions/2.7/lib/libpython2.7.dylib"
-        export BUILD_FLAGS="$BUILD_FLAGS -DPYTHON_INCLUDE_DIR=/System/Library/Frameworks/Python.framework/Versions/2.7/include/python2.7"
+        export PYINST=/System/Library/Frameworks/Python.framework/Versions
+        export PY_EXE=$PYINST/$PYMVER.7/bin/python2.7
+        export BUILD_FLAGS="$BUILD_FLAGS -DPYTHON_LIBRARY=$PYINST/2.7/lib/libpython2.7.dylib"
+        export BUILD_FLAGS="$BUILD_FLAGS -DPYTHON_INCLUDE_DIR=$PYINST/2.7/include/python2.7"
       else
         brew install python3
-        alias python$PYMVER=/usr/local/Cellar/python3/3.6.4_2/Frameworks/Python.framework/Versions/3.6/bin/python3.6
-        export BUILD_FLAGS="$BUILD_FLAGS -DPYTHON_EXECUTABLE=/usr/local/Cellar/python3/3.6.4_2/Frameworks/Python.framework/Versions/3.6/bin/python3.6"
-        export BUILD_FLAGS="$BUILD_FLAGS -DPYTHON_LIBRARY=/usr/local/Cellar/python3/3.6.4_2/Frameworks/Python.framework/Versions/3.6/Python"
-        export BUILD_FLAGS="$BUILD_FLAGS -DPYTHON_INCLUDE_DIR=/usr/local/Cellar/python3/3.6.4_2/Frameworks/Python.framework/Versions/3.6/include/python3.6m"
+        export PYINST=/usr/local/Cellar/python3/3.6.4_2/Frameworks/Python.framework/Versions
+        export PY_EXE=$PYINST/$PYMVER.6/bin/python3.6
+        export BUILD_FLAGS="$BUILD_FLAGS -DPYTHON_LIBRARY=$PYINST/3.6/Python"
+        export BUILD_FLAGS="$BUILD_FLAGS -DPYTHON_INCLUDE_DIR=$PYINST/3.6/include/python3.6m"
       fi
+      export BUILD_FLAGS="$BUILD_FLAGS -DPYTHON_EXECUTABLE=$PY_EXE"
       brew update
       brew tap homebrew/science
-      # Note: boost is already installed on osx on travis
-      # so should not be included. However, we currently need boost-python
-      # brew install boost-python
-      # for osx, 1.66 works, but 1.65 doesn't so update.
+      # boost is already installed but 1.65 doesn't work so update
       brew upgrade boost
+      # we currently need boost-python
+      # brew install boost-python
       brew install ace
       brew install swig
       brew install ccache
@@ -119,6 +139,7 @@ before_install:
       tar xzf cmake.tar.gz
       mv cmake-*/CMake.app/Contents/* cmake-*
     elif [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
+      export PY_EXE=python$PYMVER
       curl -0 https://cmake.org/files/v3.7/cmake-3.7.2-Linux-x86_64.tar.gz -o cmake.tar.gz
       tar xzf cmake.tar.gz
     fi
@@ -128,27 +149,25 @@ before_install:
  - popd
  # get pip
  - curl -0 https://bootstrap.pypa.io/get-pip.py -o get-pip.py
- - python$PYMVER get-pip.py --user
+ - $PY_EXE get-pip.py --user
  # setuptools may be out of date on osx
- - python$PYMVER -m pip install --user -U pip setuptools wheel
+ - $PY_EXE -m pip install --user -U pip setuptools wheel
  # ensure python bin dir exists (and coverage dependencies installed)
- - python$PYMVER -m pip install --user -U nose 
- - python$PYMVER -m pip install --user -U codecov
- - python$PYMVER -m pip install --user -U coveralls
+ - $PY_EXE -m pip install --user -U nose codecov coveralls
  # pip path fix
  - |
     if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
       # show lib/site-packages path
-      python$PYMVER -m pydoc pip | grep -i -A 1 file
-      python$PYMVER -m pydoc codecov | grep -i -A 1 file
+      $PY_EXE -m pydoc pip | grep -i -A 1 file
+      $PY_EXE -m pydoc codecov | grep -i -A 1 file
       # append python bin dir to path (consult output from previous lines)
       pushd $HOME/Library/Python/$PYMVER*/bin
       export PATH="$PWD:$PATH"
       popd
     fi
- - python$PYMVER --version
- - python$PYMVER -m pip --version
- - python$PYMVER -m pip freeze
+ - $PY_EXE --version
+ - $PY_EXE -m pip --version
+ - $PY_EXE -m pip freeze
  # ccache compiler override
  - ln -s "$(which ccache)" g++
  - ln -s "$(which ccache)" g++-5
@@ -160,11 +179,7 @@ before_install:
  - export BUILD_FLAGS="$BUILD_FLAGS -DPYVER=$PYMVER"
 
 install:
- #- python$PYMVER -m pip install --user --only-binary=numpy,scipy,matplotlib numpy scipy matplotlib
- - python$PYMVER -m pip install --user --only-binary=numpy numpy
- - python$PYMVER -m pip install --user --only-binary=scipy scipy
- - python$PYMVER -m pip install --user --only-binary=matplotlib matplotlib
- # python$PYMVER -m pip install --user nose codecov coveralls
+ - $PY_EXE -m pip install --user --only-binary=numpy,scipy,matplotlib numpy scipy matplotlib
  - cmake $BUILD_FLAGS $EXTRA_BUILD_FLAGS .
  # Job may timeout (>50min) if no ccache, otherwise should be <1min:
  - make

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,34 +16,30 @@ language: cpp
 # so try to keep this concise to avoid need to update
 matrix:
  include:
- - os: linux
-   python: 3
-   env: EXTRA_BUILD_FLAGS="-DUSE_SYSTEM_Boost=ON -DUSE_SYSTEM_HDF5=ON -DUSE_SYSTEM_FFTW3=ON" CC=gcc-5 CXX=g++-5 PYMVER=3
- - os: linux
-   python: 2.7
-   env: EXTRA_BUILD_FLAGS="-DUSE_SYSTEM_Boost=ON -DUSE_SYSTEM_SWIG=ON -DUSE_SYSTEM_HDF5=ON -DUSE_SYSTEM_FFTW3=ON -DBUILD_siemens_to_ismrmrd=ON" CC=gcc-5 CXX=g++-5 PYMVER=2
- - os: linux
-   python: 3
-   env: EXTRA_BUILD_FLAGS="-DUSE_SYSTEM_Boost=ON -DUSE_SYSTEM_HDF5=OFF -DUSE_SYSTEM_FFTW3=OFF -DDEVEL_BUILD=ON -DBUILD_siemens_to_ismrmrd=ON" CC=gcc-5 CXX=g++-5 PYMVER=3
- - os: linux
-   python: 2.7
-   env: EXTRA_BUILD_FLAGS="-DUSE_SYSTEM_Boost=ON -DUSE_SYSTEM_SWIG=OFF -DUSE_SYSTEM_HDF5=OFF -DUSE_SYSTEM_FFTW3=OFF -DDEVEL_BUILD=ON" CC=gcc-5 CXX=g++-5 PYMVER=2
- #- os: osx
- #  language: generic
- #  env: EXTRA_BUILD_FLAGS="-DUSE_SYSTEM_HDF5=OFF -DUSE_SYSTEM_SWIG=OFF -DPYTHON_LIBRARY=$(python-config --prefix)/lib/libpython2.7.dylib -DPYTHON_INCLUDE_DIR=$(python-config --prefix)/include/python2.7" CC=gcc CXX=g++ PYMVER=2
- #- os: osx
- #  language: generic
- #  env: EXTRA_BUILD_FLAGS="-DUSE_SYSTEM_HDF5=OFF -DUSE_SYSTEM_SWIG=ON -DDEVEL_BUILD=ON -DPYTHON_LIBRARY=$(python-config --prefix)/lib/libpython2.7.dylib -DPYTHON_INCLUDE_DIR=$(python-config --prefix)/include/python2.7" CC=gcc CXX=g++ PYMVER=2
- #- os: osx
- #  language: generic
- #  env: EXTRA_BUILD_FLAGS="-DUSE_SYSTEM_SWIG=ON -DUSE_SYSTEM_HDF5=OFF -DUSE_SYSTEM_FFTW3=OFF -DDEVEL_BUILD=ON -DPYTHON_LIBRARY=$(python-config --prefix)/lib/libpython2.7.dylib -DPYTHON_INCLUDE_DIR=$(python-config --prefix)/include/python2.7" CC=gcc CXX=g++ PYMVER=2
- # itk
- - os: linux
-   python: 3
-   env: EXTRA_BUILD_FLAGS="-DUSE_SYSTEM_Boost=ON -DUSE_SYSTEM_HDF5=ON -DUSE_SYSTEM_FFTW3=ON -DUSE_ITK=ON" CC=gcc-5 CXX=g++-5 PYMVER=3
- #- os: osx
- #  language: generic
- #  env: EXTRA_BUILD_FLAGS="-DUSE_SYSTEM_HDF5=OFF -DUSE_SYSTEM_SWIG=OFF -DPYTHON_LIBRARY=$(python-config --prefix)/lib/libpython2.7.dylib -DPYTHON_INCLUDE_DIR=$(python-config --prefix)/include/python2.7 -DUSE_ITK=ON" CC=gcc CXX=g++ PYMVER=2
+ #- os: linux
+ #  python: 3
+ #  env: EXTRA_BUILD_FLAGS="-DUSE_SYSTEM_Boost=ON -DUSE_SYSTEM_HDF5=ON -DUSE_SYSTEM_FFTW3=ON" CC=gcc-5 CXX=g++-5 PYMVER=3
+ #- os: linux
+ #  python: 2.7
+ #  env: EXTRA_BUILD_FLAGS="-DUSE_SYSTEM_Boost=ON -DUSE_SYSTEM_SWIG=ON -DUSE_SYSTEM_HDF5=ON -DUSE_SYSTEM_FFTW3=ON -DBUILD_siemens_to_ismrmrd=ON" CC=gcc-5 CXX=g++-5 PYMVER=2
+ #- os: linux
+ #  python: 3
+ #  env: EXTRA_BUILD_FLAGS="-DUSE_SYSTEM_Boost=ON -DUSE_SYSTEM_HDF5=OFF -DUSE_SYSTEM_FFTW3=OFF -DDEVEL_BUILD=ON -DBUILD_siemens_to_ismrmrd=ON" CC=gcc-5 CXX=g++-5 PYMVER=3
+ #- os: linux
+ #  python: 2.7
+ #  env: EXTRA_BUILD_FLAGS="-DUSE_SYSTEM_Boost=ON -DUSE_SYSTEM_SWIG=OFF -DUSE_SYSTEM_HDF5=OFF -DUSE_SYSTEM_FFTW3=OFF -DDEVEL_BUILD=ON" CC=gcc-5 CXX=g++-5 PYMVER=2
+ #- os: linux
+ #  python: 3
+ #  env: EXTRA_BUILD_FLAGS="-DUSE_SYSTEM_Boost=ON -DUSE_SYSTEM_HDF5=ON -DUSE_SYSTEM_FFTW3=ON -DUSE_ITK=ON" CC=gcc-5 CXX=g++-5 PYMVER=3
+ - os: osx
+   language: generic
+   env: EXTRA_BUILD_FLAGS="-DSHARED_LIBS_ABS_PATH=ON -DUSE_SYSTEM_Boost=ON -DUSE_SYSTEM_HDF5=OFF -DUSE_SYSTEM_SWIG=OFF" CC=gcc CXX=g++ PYMVER=2
+ - os: osx
+   language: generic
+   env: EXTRA_BUILD_FLAGS="-DSHARED_LIBS_ABS_PATH=ON -DUSE_SYSTEM_Boost=ON -DUSE_SYSTEM_HDF5=OFF -DUSE_SYSTEM_SWIG=OFF" CC=gcc CXX=g++ PYMVER=3
+ - os: osx
+   language: generic
+   env: EXTRA_BUILD_FLAGS="-DSHARED_LIBS_ABS_PATH=OFF -DUSE_SYSTEM_Boost=ON -DUSE_SYSTEM_HDF5=OFF -DUSE_SYSTEM_SWIG=OFF" CC=gcc CXX=g++ PYMVER=3
 env:
  global:
   - BUILD_FLAGS="-DCMAKE_BUILD_TYPE=Release"
@@ -94,11 +90,25 @@ before_install:
  - pushd ~/.local/bin
  - |
     if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
+      if [ $PYMVER == 2 ]; then
+        alias python$PYMVER=/System/Library/Frameworks/Python.framework/Versions/2.7/bin/python2.7
+        export BUILD_FLAGS="$BUILD_FLAGS -DPYTHON_EXECUTABLE=/System/Library/Frameworks/Python.framework/Versions/2.7/bin/python2.7"
+        export BUILD_FLAGS="$BUILD_FLAGS -DPYTHON_LIBRARY=/System/Library/Frameworks/Python.framework/Versions/2.7/lib/libpython2.7.dylib"
+        export BUILD_FLAGS="$BUILD_FLAGS -DPYTHON_INCLUDE_DIR=/System/Library/Frameworks/Python.framework/Versions/2.7/include/python2.7"
+      else
+        brew install python3
+        alias python$PYMVER=/usr/local/Cellar/python3/3.6.4_2/Frameworks/Python.framework/Versions/3.6/bin/python3.6
+        export BUILD_FLAGS="$BUILD_FLAGS -DPYTHON_EXECUTABLE=/usr/local/Cellar/python3/3.6.4_2/Frameworks/Python.framework/Versions/3.6/bin/python3.6"
+        export BUILD_FLAGS="$BUILD_FLAGS -DPYTHON_LIBRARY=/usr/local/Cellar/python3/3.6.4_2/Frameworks/Python.framework/Versions/3.6/Python"
+        export BUILD_FLAGS="$BUILD_FLAGS -DPYTHON_INCLUDE_DIR=/usr/local/Cellar/python3/3.6.4_2/Frameworks/Python.framework/Versions/3.6/include/python3.6m"
+      fi
       brew update
       brew tap homebrew/science
       # Note: boost is already installed on osx on travis
       # so should not be included. However, we currently need boost-python
       # brew install boost-python
+      # for osx, 1.66 works, but 1.65 doesn't so update.
+      brew upgrade boost
       brew install ace
       brew install swig
       brew install ccache
@@ -122,7 +132,9 @@ before_install:
  # setuptools may be out of date on osx
  - python$PYMVER -m pip install --user -U pip setuptools wheel
  # ensure python bin dir exists (and coverage dependencies installed)
- - python$PYMVER -m pip install --user -U nose codecov coveralls
+ - python$PYMVER -m pip install --user -U nose 
+ - python$PYMVER -m pip install --user -U codecov
+ - python$PYMVER -m pip install --user -U coveralls
  # pip path fix
  - |
     if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
@@ -133,10 +145,6 @@ before_install:
       pushd $HOME/Library/Python/$PYMVER*/bin
       export PATH="$PWD:$PATH"
       popd
-      # fix CMake variables
-      #export BUILD_FLAGS="$BUILD_FLAGS -DPYTHON_LIBRARY=$(python-config --prefix)/lib/libpython2.7.dylib"
-      #export BUILD_FLAGS="$BUILD_FLAGS -DPYTHON_INCLUDE_DIR=$(python-config --prefix)/include/python2.7"
-      export BUILD_FLAGS="$BUILD_FLAGS -DPYTHON_EXECUTABLE=$(which python$PYMVER)"
     fi
  - python$PYMVER --version
  - python$PYMVER -m pip --version
@@ -152,7 +160,10 @@ before_install:
  - export BUILD_FLAGS="$BUILD_FLAGS -DPYVER=$PYMVER"
 
 install:
- - python$PYMVER -m pip install --user --only-binary=numpy,scipy,matplotlib numpy scipy matplotlib
+ #- python$PYMVER -m pip install --user --only-binary=numpy,scipy,matplotlib numpy scipy matplotlib
+ - python$PYMVER -m pip install --user --only-binary=numpy numpy
+ - python$PYMVER -m pip install --user --only-binary=scipy scipy
+ - python$PYMVER -m pip install --user --only-binary=matplotlib matplotlib
  # python$PYMVER -m pip install --user nose codecov coveralls
  - cmake $BUILD_FLAGS $EXTRA_BUILD_FLAGS .
  # Job may timeout (>50min) if no ccache, otherwise should be <1min:
@@ -162,6 +173,8 @@ install:
 
 script:
  - ./INSTALL/bin/gadgetron >& gadgetron.log&
+ # print for debugging
+ - cat SIRF-prefix/src/SIRF-build/CMakeCache.txt
  - ctest -VV
  # print for debugging
  - cat SIRF-prefix/src/SIRF-build/Testing/Temporary/LastTest.log

--- a/SuperBuild.cmake
+++ b/SuperBuild.cmake
@@ -41,6 +41,18 @@ if(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
   set(CMAKE_INSTALL_PREFIX "${CMAKE_CURRENT_BINARY_DIR}/INSTALL" CACHE PATH "Prefix for path for installation" FORCE)
 endif()
 
+# If OSX give the advanced option to use absolute paths for shared libraries
+if (APPLE)
+  option(SHARED_LIBS_ABS_PATH "Force shared libraries to be installed with absolute paths (as opposed to rpaths)" ON)
+  mark_as_advanced( SHARED_LIBS_ABS_PATH )
+  if (SHARED_LIBS_ABS_PATH)
+    # Set install_name_dir as the absolute path to install_prefix/lib
+    GET_FILENAME_COMPONENT(CMAKE_INSTALL_NAME_DIR ${CMAKE_INSTALL_PREFIX}/lib REALPATH)
+    # Mark it as superbuild so that it gets passed to all dependencies
+    mark_as_superbuild( PROJECTS ALL_PROJECTS VARS CMAKE_INSTALL_NAME_DIR:PATH )
+  endif(SHARED_LIBS_ABS_PATH)
+endif(APPLE)
+
 set (SUPERBUILD_INSTALL_DIR ${CMAKE_INSTALL_PREFIX})
 
 include(ExternalProject)
@@ -164,7 +176,7 @@ if(PYTHONINTERP_FOUND)
       setenv SIRF_PYTHON_EXECUTABLE ${PYTHON_EXECUTABLE}")
 
   set (ENV_PYTHON_BASH "\
-     PYTHONPATH=${PYTHON_DEST}:$PYTHONPATH \n\ 
+     PYTHONPATH=${PYTHON_DEST}:$PYTHONPATH \n\
      export PYTHONPATH \n\
      SIRF_PYTHON_EXECUTABLE=${PYTHON_EXECUTABLE} \n\
      export SIRF_PYTHON_EXECUTABLE")


### PR DESCRIPTION
Get OSX to compile on Travis.
- Use absolute paths
- Give full paths to python executable, library and include directory for either python2 or python3.\
- Upgrade to boost 1.66