### PR TITLE
Add option to build UCL/petmr-rd-tools

### DIFF
--- a/SuperBuild.cmake
+++ b/SuperBuild.cmake
@@ -137,6 +137,10 @@ if (BUILD_siemens_to_ismrmrd)
   list(APPEND ${PRIMARY_PROJECT_NAME}_DEPENDENCIES siemens_to_ismrmrd)
 endif()
 
+if (BUILD_petmr_rd_tools)
+  list(APPEND ${PRIMARY_PROJECT_NAME}_DEPENDENCIES petmr_rd_tools)
+endif()
+
 ExternalProject_Include_Dependencies(${proj} DEPENDS_VAR ${PRIMARY_PROJECT_NAME}_DEPENDENCIES)
 
 message(STATUS "")

--- a/SuperBuild.cmake
+++ b/SuperBuild.cmake
@@ -124,6 +124,7 @@ endif()
 
 option(BUILD_GADGETRON "Build Gadgetron" ${build_Gadgetron_default})
 option(BUILD_siemens_to_ismrmrd "Build siemens_to_ismrmrd" OFF)
+option(BUILD_petmr_rd_tools "Build petmr_rd_tools" OFF)
 
 set(${PRIMARY_PROJECT_NAME}_DEPENDENCIES
     SIRF

--- a/SuperBuild.cmake
+++ b/SuperBuild.cmake
@@ -110,12 +110,6 @@ option(USE_SYSTEM_SIRF "Build using an external version of SIRF" OFF)
 option(USE_SYSTEM_GTest "Build using an external version of GTest" OFF)
 option(BUILD_STIR_WITH_OPENMP "Build STIR with OpenMP acceleration" OFF)
 
-# ITK
-option(USE_ITK "Use ITK" OFF)
-if (USE_ITK)
-  option(USE_SYSTEM_ITK "Build using an external version of ITK" OFF)
-endif()
-
 if (WIN32)
   set(build_Gadgetron_default OFF)
 else()
@@ -125,6 +119,16 @@ endif()
 option(BUILD_GADGETRON "Build Gadgetron" ${build_Gadgetron_default})
 option(BUILD_siemens_to_ismrmrd "Build siemens_to_ismrmrd" OFF)
 option(BUILD_petmr_rd_tools "Build petmr_rd_tools" OFF)
+
+if (BUILD_petmr_rd_tools)
+    set(USE_ITK ON CACHE BOOL "Use ITK" FORCE)
+endif()
+
+# ITK
+option(USE_ITK "Use ITK" OFF)
+if (USE_ITK)
+  option(USE_SYSTEM_ITK "Build using an external version of ITK" OFF)
+endif()
 
 set(${PRIMARY_PROJECT_NAME}_DEPENDENCIES
     SIRF

--- a/SuperBuild.cmake
+++ b/SuperBuild.cmake
@@ -122,6 +122,7 @@ option(BUILD_petmr_rd_tools "Build petmr_rd_tools" OFF)
 
 if (BUILD_petmr_rd_tools)
     set(USE_ITK ON CACHE BOOL "Use ITK" FORCE)
+    option(USE_SYSTEM_glog "Build using an external version of glog" OFF)
 endif()
 
 # ITK

--- a/SuperBuild/External_glog.cmake
+++ b/SuperBuild/External_glog.cmake
@@ -1,9 +1,7 @@
 #========================================================================
 # Author: Benjamin A Thomas
 # Author: Kris Thielemans
-# Author: Edoardo Pasca
-# Copyright 2017, 2018 University College London
-# Copyright 2017 STFC
+# Copyright 2017 University College London
 #
 # This file is part of the CCP PETMR Synergistic Image Reconstruction Framework (SIRF) SuperBuild.
 #
@@ -22,10 +20,10 @@
 #=========================================================================
 
 #This needs to be unique globally
-set(proj petmr_rd_tools)
+set(proj glog)
 
 # Set dependency list
-set(${proj}_DEPENDENCIES "Boost;ITK;glog")
+#set(${proj}_DEPENDENCIES "")
 
 # Include dependent projects if any
 ExternalProject_Include_Dependencies(${proj} DEPENDS_VAR ${proj}_DEPENDENCIES)
@@ -39,49 +37,32 @@ set(${proj}_DOWNLOAD_DIR "${SUPERBUILD_WORK_DIR}/downloads/${proj}" )
 set(${proj}_STAMP_DIR "${SUPERBUILD_WORK_DIR}/builds/${proj}/stamp" )
 set(${proj}_TMP_DIR "${SUPERBUILD_WORK_DIR}/builds/${proj}/tmp" )
 
+
 if(NOT ( DEFINED "USE_SYSTEM_${externalProjName}" AND "${USE_SYSTEM_${externalProjName}}" ) )
   message(STATUS "${__indent}Adding project ${proj}")
 
   ### --- Project specific additions here
-  set(petmr_rd_tools_Install_Dir ${SUPERBUILD_INSTALL_DIR})
+  set(glog_Install_Dir ${SUPERBUILD_INSTALL_DIR})
 
-  set(CMAKE_LIBRARY_PATH ${CMAKE_LIBRARY_PATH} ${SUPERBUILD_INSTALL_DIR})
-  set(CMAKE_INCLUDE_PATH ${CMAKE_INCLUDE_PATH} ${SUPERBUILD_INSTALL_DIR})
-
-  set(petmr_rd_tools_CMAKE_ARGS
-      -DCMAKE_PREFIX_PATH=${SUPERBUILD_INSTALL_DIR}
-      -DCMAKE_LIBRARY_PATH=${SUPERBUILD_INSTALL_DIR}/lib
-      -DCMAKE_INCLUDE_PATH=${SUPERBUILD_INSTALL_DIR}
-      -DCMAKE_INSTALL_PREFIX=${petmr_rd_tools_Install_Dir}
-      -DBOOST_INCLUDEDIR=${BOOST_ROOT}/include/
-      -DBOOST_LIBRARYDIR=${BOOST_LIBRARY_DIR}
-      -Dglog_DIR=${glog_DIR}
-      )
-
-  if (USE_SYSTEM_ITK)
-    set(petmr_rd_tools_CMAKE_ARGS ${petmr_rd_tools_CMAKE_ARGS} 
-      -DITK_DIR=${ITK_DIR}
-      )
-  endif()
+  set(glog_CMAKE_ARGS 
+        -DCMAKE_INSTALL_PREFIX=${glog_Install_Dir}
+   )
 
   ExternalProject_Add(${proj}
     ${${proj}_EP_ARGS}
     GIT_REPOSITORY ${${proj}_URL}
-    GIT_TAG ${${proj}_TAG}
-
+    GIT_TAG ${STIR_TAG}
     SOURCE_DIR ${${proj}_SOURCE_DIR}
     BINARY_DIR ${${proj}_BINARY_DIR}
     DOWNLOAD_DIR ${${proj}_DOWNLOAD_DIR}
     STAMP_DIR ${${proj}_STAMP_DIR}
     TMP_DIR ${${proj}_TMP_DIR}
-    CMAKE_ARGS ${petmr_rd_tools_CMAKE_ARGS}
-    INSTALL_DIR ${petmr_rd_tools_Install_Dir}
+	
+    CMAKE_ARGS ${glog_CMAKE_ARGS}
+    INSTALL_DIR ${glog_Install_Dir}
     DEPENDS
         ${${proj}_DEPENDENCIES}
   )
-
-    set(petmr_rd_tools_ROOT        ${petmr_rd_tools_SOURCE_DIR})
-    set(petmr_rd_tools_INCLUDE_DIR ${petmr_rd_tools_SOURCE_DIR})
 
    else()
       if(${USE_SYSTEM_${externalProjName}})

--- a/SuperBuild/External_petmr_rd_tools.cmake
+++ b/SuperBuild/External_petmr_rd_tools.cmake
@@ -25,8 +25,8 @@
 set(proj petmr_rd_tools)
 
 # Set dependency list
-set(${proj}_DEPENDENCIES "Boost;ITK;GLOG")
-# TODO should add LibXml2, LibXslt
+set(${proj}_DEPENDENCIES "Boost")
+# Also requires ITK and glog
 
 # Include dependent projects if any
 ExternalProject_Include_Dependencies(${proj} DEPENDS_VAR ${proj}_DEPENDENCIES)

--- a/SuperBuild/External_petmr_rd_tools.cmake
+++ b/SuperBuild/External_petmr_rd_tools.cmake
@@ -25,8 +25,8 @@
 set(proj petmr_rd_tools)
 
 # Set dependency list
-set(${proj}_DEPENDENCIES "Boost")
-# Also requires ITK and glog
+set(${proj}_DEPENDENCIES "Boost;ITK")
+# Also requires glog
 
 # Include dependent projects if any
 ExternalProject_Include_Dependencies(${proj} DEPENDS_VAR ${proj}_DEPENDENCIES)
@@ -48,27 +48,32 @@ if(NOT ( DEFINED "USE_SYSTEM_${externalProjName}" AND "${USE_SYSTEM_${externalPr
 
   set(CMAKE_LIBRARY_PATH ${CMAKE_LIBRARY_PATH} ${SUPERBUILD_INSTALL_DIR})
   set(CMAKE_INCLUDE_PATH ${CMAKE_INCLUDE_PATH} ${SUPERBUILD_INSTALL_DIR})
-  
-  
+
+  set(petmr_rd_tools_CMAKE_ARGS
+      -DCMAKE_PREFIX_PATH=${SUPERBUILD_INSTALL_DIR}
+      -DCMAKE_LIBRARY_PATH=${SUPERBUILD_INSTALL_DIR}/lib
+      -DCMAKE_INCLUDE_PATH=${SUPERBUILD_INSTALL_DIR}
+      -DCMAKE_INSTALL_PREFIX=${petmr_rd_tools_Install_Dir}
+      -DBOOST_INCLUDEDIR=${BOOST_ROOT}/include/
+      -DBOOST_LIBRARYDIR=${BOOST_LIBRARY_DIR}
+      )
+
+  if (USE_SYSTEM_ITK)
+    set(petmr_rd_tools_CMAKE_ARGS ${petmr_rd_tools_CMAKE_ARGS} -DITK_DIR=${ITK_DIR})
+  endif()
+
   ExternalProject_Add(${proj}
     ${${proj}_EP_ARGS}
     GIT_REPOSITORY ${${proj}_URL}
     GIT_TAG ${${proj}_TAG}
-	
+
     SOURCE_DIR ${${proj}_SOURCE_DIR}
     BINARY_DIR ${${proj}_BINARY_DIR}
     DOWNLOAD_DIR ${${proj}_DOWNLOAD_DIR}
     STAMP_DIR ${${proj}_STAMP_DIR}
     TMP_DIR ${${proj}_TMP_DIR}
-
-    CMAKE_ARGS
-        -DCMAKE_PREFIX_PATH=${SUPERBUILD_INSTALL_DIR}
-        -DCMAKE_LIBRARY_PATH=${SUPERBUILD_INSTALL_DIR}/lib
-        -DCMAKE_INCLUDE_PATH=${SUPERBUILD_INSTALL_DIR}
-        -DCMAKE_INSTALL_PREFIX=${petmr_rd_tools_Install_Dir}
-        -DBOOST_INCLUDEDIR=${BOOST_ROOT}/include/
-        -DBOOST_LIBRARYDIR=${BOOST_LIBRARY_DIR}
-	    INSTALL_DIR ${petmr_rd_tools_Install_Dir}
+    CMAKE_ARGS ${petmr_rd_tools_CMAKE_ARGS}
+	INSTALL_DIR ${petmr_rd_tools_Install_Dir}
     DEPENDS
         ${${proj}_DEPENDENCIES}
   )

--- a/SuperBuild/External_petmr_rd_tools.cmake
+++ b/SuperBuild/External_petmr_rd_tools.cmake
@@ -1,0 +1,98 @@
+#========================================================================
+# Author: Benjamin A Thomas
+# Author: Kris Thielemans
+# Author: Edoardo Pasca
+# Copyright 2017, 2018 University College London
+# Copyright 2017 STFC
+#
+# This file is part of the CCP PETMR Synergistic Image Reconstruction Framework (SIRF) SuperBuild.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+#=========================================================================
+
+#This needs to be unique globally
+set(proj petmr_rd_tools)
+
+# Set dependency list
+set(${proj}_DEPENDENCIES "Boost;ITK;GLOG")
+# TODO should add LibXml2, LibXslt
+
+# Include dependent projects if any
+ExternalProject_Include_Dependencies(${proj} DEPENDS_VAR ${proj}_DEPENDENCIES)
+
+# Set external name (same as internal for now)
+set(externalProjName ${proj})
+
+set(${proj}_SOURCE_DIR "${SOURCE_ROOT_DIR}/${proj}" )
+set(${proj}_BINARY_DIR "${SUPERBUILD_WORK_DIR}/builds/${proj}/build" )
+set(${proj}_DOWNLOAD_DIR "${SUPERBUILD_WORK_DIR}/downloads/${proj}" )
+set(${proj}_STAMP_DIR "${SUPERBUILD_WORK_DIR}/builds/${proj}/stamp" )
+set(${proj}_TMP_DIR "${SUPERBUILD_WORK_DIR}/builds/${proj}/tmp" )
+
+if(NOT ( DEFINED "USE_SYSTEM_${externalProjName}" AND "${USE_SYSTEM_${externalProjName}}" ) )
+  message(STATUS "${__indent}Adding project ${proj}")
+
+  ### --- Project specific additions here
+  set(petmr_rd_tools_Install_Dir ${SUPERBUILD_INSTALL_DIR})
+
+  set(CMAKE_LIBRARY_PATH ${CMAKE_LIBRARY_PATH} ${SUPERBUILD_INSTALL_DIR})
+  set(CMAKE_INCLUDE_PATH ${CMAKE_INCLUDE_PATH} ${SUPERBUILD_INSTALL_DIR})
+  
+  
+  ExternalProject_Add(${proj}
+    ${${proj}_EP_ARGS}
+    GIT_REPOSITORY ${${proj}_URL}
+    GIT_TAG ${${proj}_TAG}
+	
+    SOURCE_DIR ${${proj}_SOURCE_DIR}
+    BINARY_DIR ${${proj}_BINARY_DIR}
+    DOWNLOAD_DIR ${${proj}_DOWNLOAD_DIR}
+    STAMP_DIR ${${proj}_STAMP_DIR}
+    TMP_DIR ${${proj}_TMP_DIR}
+
+    CMAKE_ARGS
+        -DCMAKE_PREFIX_PATH=${SUPERBUILD_INSTALL_DIR}
+        -DCMAKE_LIBRARY_PATH=${SUPERBUILD_INSTALL_DIR}/lib
+        -DCMAKE_INCLUDE_PATH=${SUPERBUILD_INSTALL_DIR}
+        -DCMAKE_INSTALL_PREFIX=${petmr_rd_tools_Install_Dir}
+        -DBOOST_INCLUDEDIR=${BOOST_ROOT}/include/
+        -DBOOST_LIBRARYDIR=${BOOST_LIBRARY_DIR}
+	    INSTALL_DIR ${petmr_rd_tools_Install_Dir}
+    DEPENDS
+        ${${proj}_DEPENDENCIES}
+  )
+
+    set(petmr_rd_tools_ROOT        ${petmr_rd_tools_SOURCE_DIR})
+    set(petmr_rd_tools_INCLUDE_DIR ${petmr_rd_tools_SOURCE_DIR})
+
+   else()
+      if(${USE_SYSTEM_${externalProjName}})
+        find_package(${proj} ${${externalProjName}_REQUIRED_VERSION} REQUIRED)
+        message("USING the system ${externalProjName}, set ${externalProjName}_DIR=${${externalProjName}_DIR}")
+   endif()
+    ExternalProject_Add_Empty(${proj} DEPENDS "${${proj}_DEPENDENCIES}"
+    SOURCE_DIR ${${proj}_SOURCE_DIR}
+    BINARY_DIR ${${proj}_BINARY_DIR}
+    DOWNLOAD_DIR ${${proj}_DOWNLOAD_DIR}
+    STAMP_DIR ${${proj}_STAMP_DIR}
+    TMP_DIR ${${proj}_TMP_DIR}
+   )
+  endif()
+
+  mark_as_superbuild(
+    VARS
+      ${externalProjName}_DIR:PATH
+    LABELS
+      "FIND_PACKAGE"
+  )

--- a/version_config.cmake
+++ b/version_config.cmake
@@ -103,6 +103,11 @@ if (DEVEL_BUILD)
   set(DEFAULT_ISMRMRD_URL https://github.com/ismrmrd/ismrmrd )
   set(DEFAULT_ISMRMRD_TAG origin/master)
 
+  ## petmr-rd-tools
+  set(DEFAULT_petmr_rd_tools_URL https://github.com/UCL/petmr-rd-tools )
+  set(DEFAULT_petmr_rd_tools_TAG origin/master)
+
+
 else()
   set(DEFAULT_SIRF_TAG 6409e3753940136077b658af67112bd28545a3ce)
 
@@ -125,6 +130,10 @@ else()
   set(DEFAULT_ISMRMRD_URL https://github.com/ismrmrd/ismrmrd )
   set(DEFAULT_ISMRMRD_TAG 42d93137cc16c270c8ba065edd2496483161bd21)
 
+  ## petmr-rd-tools
+  set(DEFAULT_petmr_rd_tools_URL https://github.com/UCL/petmr-rd-tools )
+  set(DEFAULT_petmr_rd_tools_TAG b6f46e777b1a5ecec52d5cf0573a0f070f9b277b)
+
 endif()
 
 
@@ -145,7 +154,11 @@ SET(siemens_to_ismrmrd_URL ${DEFAULT_siemens_to_ismrmrd_URL} CACHE STRING ON)
 SET(ISMRMRD_TAG ${DEFAULT_ISMRMRD_TAG} CACHE STRING ON)
 SET(ISMRMRD_URL ${DEFAULT_ISMRMRD_URL} CACHE STRING ON)
 
+SET(petmr_rd_tools_TAG ${DEFAULT_petmr_rd_tools_TAG} CACHE STRING ON)
+SET(petmr_rd_tools_URL ${DEFAULT_petmr_rd_tools_URL} CACHE STRING ON)
+
 mark_as_advanced(SIRF_URL SIRF_TAG STIR_URL STIR_TAG
   Gadgetron_URL Gadgetron_TAG
   siemens_to_ismrmrd_URL siemens_to_ismrmrd_TAG
-  ISMRMRD_URL ISMRMRD_TAG)
+  ISMRMRD_URL ISMRMRD_TAG
+  petmr_rd_tools_URL petmr_rd_tools_TAG)

--- a/version_config.cmake
+++ b/version_config.cmake
@@ -73,6 +73,10 @@ option(DEVEL_BUILD "Use current versions of major packages" OFF)
 set(GTest_URL https://github.com/google/googletest )
 set(GTest_TAG release-1.8.0)
 
+## glog
+set(glog_URL https://github.com/google/glog )
+set(glog_TAG v035)
+
 ## ITK
 set(ITK_URL https://itk.org/ITK.git)
 set(ITK_TAG v4.13.0)
@@ -107,6 +111,9 @@ if (DEVEL_BUILD)
   set(DEFAULT_petmr_rd_tools_URL https://github.com/UCL/petmr-rd-tools )
   set(DEFAULT_petmr_rd_tools_TAG origin/master)
 
+  ## glog
+  set(DEFAULT_glog_URL https://github.com/google/glog )
+  set(DEFAULT_glog_TAG v035)
 
 else()
   set(DEFAULT_SIRF_TAG 6409e3753940136077b658af67112bd28545a3ce)
@@ -134,6 +141,10 @@ else()
   set(DEFAULT_petmr_rd_tools_URL https://github.com/UCL/petmr-rd-tools )
   set(DEFAULT_petmr_rd_tools_TAG b6f46e777b1a5ecec52d5cf0573a0f070f9b277b)
 
+  ## glog
+  set(DEFAULT_glog_URL https://github.com/google/glog )
+  set(DEFAULT_glog_TAG v035)
+
 endif()
 
 
@@ -157,8 +168,12 @@ SET(ISMRMRD_URL ${DEFAULT_ISMRMRD_URL} CACHE STRING ON)
 SET(petmr_rd_tools_TAG ${DEFAULT_petmr_rd_tools_TAG} CACHE STRING ON)
 SET(petmr_rd_tools_URL ${DEFAULT_petmr_rd_tools_URL} CACHE STRING ON)
 
+SET(glog_URL ${DEFAULT_glog_URL} CACHE STRING ON)
+SET(glog_TAG ${DEFAULT_glog_TAG} CACHE STRING ON)
+
 mark_as_advanced(SIRF_URL SIRF_TAG STIR_URL STIR_TAG
   Gadgetron_URL Gadgetron_TAG
   siemens_to_ismrmrd_URL siemens_to_ismrmrd_TAG
   ISMRMRD_URL ISMRMRD_TAG
-  petmr_rd_tools_URL petmr_rd_tools_TAG)
+  petmr_rd_tools_URL petmr_rd_tools_TAG
+  glog_URL glog_TAG)


### PR DESCRIPTION
Will build [UCL/petmr-rd-tools](https://github.com/UCL/petmr-rd-tools) if requested. Not that both `ITK` and [glog](https://github.com/google/glog) are required to successfully build. I have left them out of the dependency list in `External_petmr_rd_tools.cmake`. Once happy, we should add this to the VM.