### PR TITLE
expose python strategy

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,11 @@
-## New in Release 1.0
+# ChangeLog
+
+## master
+
+* Added PYTHON_DEST_DIR variable, which allows the user to select the install destination of the SIRF python modules. PYTHON_DEST_DIR is a cached variable which can be updated on the GUI. If PYTHON_DEST_DIR is not set, we will install in ${CMAKE_INSTALL_PREFIX}/python. Likewise for MATLAB_DEST_DIR.
+
+## v1.0.0
+
  - optionally build siemens_to_ismrmrd
  - optionally build petmr_rd_tools
  - major [restructuring](https://github.com/CCPPETMR/SIRF-SuperBuild/issues/16#issuecomment-360772097) of SuperBuild build directory

--- a/SuperBuild.cmake
+++ b/SuperBuild.cmake
@@ -1,6 +1,7 @@
 #========================================================================
 # Author: Benjamin A Thomas
 # Author: Edoardo Pasca
+# Author: Casper da Costa-Luis
 # Copyright 2017 University College London
 # Copyright 2017 Science Technology Facilities Council
 #
@@ -178,25 +179,27 @@ set(CCPPETMR_INSTALL ${SUPERBUILD_INSTALL_DIR})
 ## in the env_ccppetmr scripts we perform a substitution of the whole block
 ## during the configure_file() command call below.
 
-## Note that the MATLAB_DEST and PYTHON_DEST variables are currently set
-## in External_SIRF.cmake. That's a bit confusing of course (TODO).
+## Note that the (MATLAB|PYTHON)_DEST and PYTHON_STRATEGY variables are
+## currently set in External_SIRF.cmake. That's a bit confusing of course (TODO).
 set(ENV_PYTHON_BASH "#####    Python not found    #####")
 set(ENV_PYTHON_CSH  "#####    Python not found    #####")
 if(PYTHONINTERP_FOUND)
+  if("${PYTHON_STRATEGY}" STREQUAL "PYTHONPATH")
+    set(COMMENT_OUT_PREFIX "")
+  else()
+    set(COMMENT_OUT_PREFIX "#")
+  endif()
 
   set (ENV_PYTHON_CSH "\
-    if $?PYTHONPATH then \n\
-      setenv PYTHONPATH ${PYTHON_DEST}:$PYTHONPATH \n\
-    else \n\
-      setenv PYTHONPATH ${PYTHON_DEST} \n\
-      setenv SIRF_PYTHON_EXECUTABLE ${PYTHON_EXECUTABLE}")
+    ${COMMENT_OUT_PREFIX}if $?PYTHONPATH then \n\
+    ${COMMENT_OUT_PREFIX}  setenv PYTHONPATH ${PYTHON_DEST}:$PYTHONPATH \n\
+    ${COMMENT_OUT_PREFIX}else \n\
+    ${COMMENT_OUT_PREFIX}  setenv PYTHONPATH ${PYTHON_DEST} \n\
+    setenv SIRF_PYTHON_EXECUTABLE ${PYTHON_EXECUTABLE}")
 
   set (ENV_PYTHON_BASH "\
-     PYTHONPATH=${PYTHON_DEST}:$PYTHONPATH \n\
-     export PYTHONPATH \n\
-     SIRF_PYTHON_EXECUTABLE=${PYTHON_EXECUTABLE} \n\
-     export SIRF_PYTHON_EXECUTABLE")
-
+    ${COMMENT_OUT_PREFIX}export PYTHONPATH=\"${PYTHON_DEST}\${PYTHONPATH:+:\${PYTHONPATH}}\" \n\
+    export SIRF_PYTHON_EXECUTABLE=${PYTHON_EXECUTABLE}")
 endif()
 
 set(ENV_MATLAB_BASH "#####     Matlab not found     #####")
@@ -218,7 +221,6 @@ endif()
 
 configure_file(env_ccppetmr.sh.in ${CCPPETMR_INSTALL}/bin/env_ccppetmr.sh)
 configure_file(env_ccppetmr.csh.in ${CCPPETMR_INSTALL}/bin/env_ccppetmr.csh)
-
 
 # add tests
 enable_testing()

--- a/SuperBuild.cmake
+++ b/SuperBuild.cmake
@@ -206,15 +206,15 @@ set(ENV_MATLAB_BASH "#####     Matlab not found     #####")
 set(ENV_MATLAB_CSH  "#####     Matlab not found     #####")
 if (Matlab_FOUND)
   set(ENV_MATLAB_BASH "\
-MATLABPATH=${MATLAB_DEST}\n\
+  MATLABPATH=${MATLAB_DEST}\n\
 export MATLABPATH\n\
 SIRF_MATLAB_EXECUTABLE=${Matlab_MAIN_PROGRAM}\n\
 export SIRF_MATLAB_EXECUTABLE")
   set(ENV_MATLAB_CSH "\
    if $?MATLABPATH then\n\
-	setenv MATLABPATH ${MATLAB_DEST}:$MATLABPATH\n\
+     setenv MATLABPATH ${MATLAB_DEST}:$MATLABPATH\n\
    else\n\
-	setenv MATLABPATH ${MATLAB_DEST}\n\
+     setenv MATLABPATH ${MATLAB_DEST}\n\
    endif\n\
    setenv SIRF_MATLAB_EXECUTABLE ${Matlab_MAIN_PROGRAM}")
 endif()

--- a/SuperBuild/External_SIRF.cmake
+++ b/SuperBuild/External_SIRF.cmake
@@ -50,6 +50,11 @@ if(NOT ( DEFINED "USE_SYSTEM_${externalProjName}" AND "${USE_SYSTEM_${externalPr
   set (BUILD_PYTHON ${PYTHONLIBS_FOUND})
   if (BUILD_PYTHON)
     set(PYTHON_DEST "${SIRF_Install_Dir}/python" CACHE PATH "Destination for python modules")
+    set(PYTHON_STRATEGY "PYTHONPATH" CACHE STRING "\
+      PYTHONPATH: prefix PYTHONPATH \n\
+      SETUP_PY:   execute ${PYTHON_EXECUTABLE} setup.py install \n\
+      CONDA:      do nothing")
+    set_property(CACHE PYTHON_STRATEGY PROPERTY STRINGS PYTHONPATH SETUP_PY CONDA)
   endif()
   set (BUILD_MATLAB ${Matlab_FOUND})
   if (BUILD_MATLAB)
@@ -58,7 +63,7 @@ if(NOT ( DEFINED "USE_SYSTEM_${externalProjName}" AND "${USE_SYSTEM_${externalPr
 
   message(STATUS "HDF5_ROOT in External_SIRF: " ${HDF5_ROOT})
   set(CMAKE_LIBRARY_PATH ${CMAKE_LIBRARY_PATH} ${SUPERBUILD_INSTALL_DIR})
-  
+
   ExternalProject_Add(${proj}
     ${${proj}_EP_ARGS}
     GIT_REPOSITORY ${${proj}_URL}
@@ -88,6 +93,7 @@ if(NOT ( DEFINED "USE_SYSTEM_${externalProjName}" AND "${USE_SYSTEM_${externalPr
         -DPYTHON_INCLUDE_DIR=${PYTHON_INCLUDE_DIRS}
         -DPYTHON_LIBRARY=${PYTHON_LIBRARIES}
         -DPYTHON_DEST=${PYTHON_DEST}
+        -DPYTHON_STRATEGY=${PYTHON_STRATEGY}
 	INSTALL_DIR ${SIRF_Install_Dir}
     DEPENDS
         ${${proj}_DEPENDENCIES}

--- a/SuperBuild/External_SIRF.cmake
+++ b/SuperBuild/External_SIRF.cmake
@@ -49,7 +49,15 @@ if(NOT ( DEFINED "USE_SYSTEM_${externalProjName}" AND "${USE_SYSTEM_${externalPr
 
   set (BUILD_PYTHON ${PYTHONLIBS_FOUND})
   if (BUILD_PYTHON)
-    set(PYTHON_DEST "${SIRF_Install_Dir}/python" CACHE PATH "Destination for python modules")
+    set(PYTHON_DEST_DIR "" CACHE PATH "Directory of the SIRF Python modules")
+    if (PYTHON_DEST_DIR)
+     set(PYTHON_DEST "${PYTHON_DEST_DIR}")
+    else()
+      set(PYTHON_DEST "${CMAKE_INSTALL_PREFIX}/python")
+    endif()
+    message(STATUS "Python libraries found")
+    message(STATUS "SIRF Python modules will be installed in " ${PYTHON_DEST})
+
     set(PYTHON_STRATEGY "PYTHONPATH" CACHE STRING "\
       PYTHONPATH: prefix PYTHONPATH \n\
       SETUP_PY:   execute ${PYTHON_EXECUTABLE} setup.py install \n\
@@ -58,7 +66,14 @@ if(NOT ( DEFINED "USE_SYSTEM_${externalProjName}" AND "${USE_SYSTEM_${externalPr
   endif()
   set (BUILD_MATLAB ${Matlab_FOUND})
   if (BUILD_MATLAB)
-    set(MATLAB_DEST "${SIRF_Install_Dir}/matlab" CACHE PATH "Destination for matlab modules")
+    set(MATLAB_DEST_DIR "" CACHE PATH "Directory of the SIRF Matlab libraries")
+    if (MATLAB_DEST_DIR)
+      set(MATLAB_DEST "${MATLAB_DEST_DIR}")
+    else()
+      set(MATLAB_DEST "${CMAKE_INSTALL_PREFIX}/matlab")
+    endif()
+    message(STATUS "Matlab libraries found")
+    message(STATUS "SIRF Matlab libraries will be installed in " ${MATLAB_DEST})
   endif()
 
   message(STATUS "HDF5_ROOT in External_SIRF: " ${HDF5_ROOT})
@@ -83,7 +98,7 @@ if(NOT ( DEFINED "USE_SYSTEM_${externalProjName}" AND "${USE_SYSTEM_${externalPr
         -DBOOST_ROOT=${BOOST_ROOT}
         -DMatlab_ROOT_DIR=${Matlab_ROOT_DIR}
         -DMATLAB_ROOT=${Matlab_ROOT_DIR} # pass this for compatibility with old SIRF
-        -DMATLAB_DEST=${MATLAB_DEST}
+        -DMATLAB_DEST_DIR=${MATLAB_DEST_DIR}
         -DSTIR_DIR=${STIR_DIR}
         -DHDF5_ROOT=${HDF5_ROOT}
         -DHDF5_INCLUDE_DIRS=${HDF5_INCLUDE_DIRS}
@@ -92,7 +107,7 @@ if(NOT ( DEFINED "USE_SYSTEM_${externalProjName}" AND "${USE_SYSTEM_${externalPr
         -DPYTHON_EXECUTABLE=${PYTHON_EXECUTABLE}
         -DPYTHON_INCLUDE_DIR=${PYTHON_INCLUDE_DIRS}
         -DPYTHON_LIBRARY=${PYTHON_LIBRARIES}
-        -DPYTHON_DEST=${PYTHON_DEST}
+        -DPYTHON_DEST_DIR=${PYTHON_DEST_DIR}
         -DPYTHON_STRATEGY=${PYTHON_STRATEGY}
 	INSTALL_DIR ${SIRF_Install_Dir}
     DEPENDS


### PR DESCRIPTION
most of this (see original description below) is migrated to https://github.com/CCPPETMR/SIRF/pull/163

# new description

- [ ] depends on https://github.com/CCPPETMR/SIRF/pull/163
    + [x] use `PYTHON_STRATEGY` (`CONDA|SETUP_PY|PYTHONPATH)`
    + [x] example: `cmake -DSIRF_TAG=setup_py -DPYTHON_STRATEGY=SETUP_PY`

# original description

- [x] provides `setup.py`
    + [x] provides `sirf`
    + [x] alias `p(Gadgetron|STIR|Utilities)` to `sirf.p(Gadgetron|STIR|Utilities)` for backward-compatibility
- [x] cmake -> ~~pip install ->~~ setup.py
- [ ] depends on https://github.com/CCPPETMR/SIRF/pull/160 (or https://github.com/CCPPETMR/SIRF/pull/161)
- [x] register `sirf` on `PyPI` before anyone else does (https://pypi.org/project/sirf/)

## old

- `INSTALL/`
    + `python/`
        * `*.(py|so)`

## new

- `INSTALL/`
    + `python/`
        * `setup.py`
        * `sirf/`
            - `__init__.py`
            - `*.(py|so)`
        * `p*/__init__.py`

## future

- [ ] (ana)conda @paskino
- [ ] register `sirf` on `conda-forge`
- [ ] `setup.py:build_ext` to call `cmake` @casperdcl
    + https://stackoverflow.com/a/48015772/3896283
    + won't need to re-implement `cmake` call in `conda`
    + will need to pass `cmake` build args to `setup.py` (pretty easy)