### PR TITLE
Glog previously used STIR version tag instead of its own.

### DIFF
--- a/SuperBuild/External_glog.cmake
+++ b/SuperBuild/External_glog.cmake
@@ -51,7 +51,7 @@ if(NOT ( DEFINED "USE_SYSTEM_${externalProjName}" AND "${USE_SYSTEM_${externalPr
   ExternalProject_Add(${proj}
     ${${proj}_EP_ARGS}
     GIT_REPOSITORY ${${proj}_URL}
-    GIT_TAG ${STIR_TAG}
+    GIT_TAG ${${proj}_TAG}
     SOURCE_DIR ${${proj}_SOURCE_DIR}
     BINARY_DIR ${${proj}_BINARY_DIR}
     DOWNLOAD_DIR ${${proj}_DOWNLOAD_DIR}


### PR DESCRIPTION
I haven't properly tested this as I haven't been able to use the superbuild, but I forgot to push this a few months ago when I found it.