### PR TITLE
Also build the boost unit_test framework and other fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -52,7 +52,7 @@ matrix:
  - os: osx
    # -boost -hdf5 -swig
    python: 3
-   env: EXTRA_BUILD_FLAGS="-DUSE_SYSTEM_Boost=OFF -DUSE_SYSTEM_HDF5=OFF -DUSE_SYSTEM_SWIG=OFF" MATRIX_EVAL="CC=gcc CXX=g++" PYMVER=3
+   env: EXTRA_BUILD_FLAGS="-DUSE_SYSTEM_Boost=OFF -DUSE_SYSTEM_HDF5=ON -DUSE_SYSTEM_SWIG=ON" MATRIX_EVAL="CC=gcc CXX=g++" PYMVER=3
  - os: osx
    python: 2.7
    # +DEVEL +boost -hdf5 +swig

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,8 +47,9 @@ matrix:
  # osx g{cc,++} py{27,36}
  - os: osx
    python: 2.7
-   # +boost -hdf5 -swig
-   env: EXTRA_BUILD_FLAGS="-DUSE_SYSTEM_Boost=ON -DUSE_SYSTEM_HDF5=OFF -DUSE_SYSTEM_SWIG=OFF" MATRIX_EVAL="CC=gcc CXX=g++" PYMVER=2
+   # Note: can't test SYSTEM_Boost=OFF due to excessive log size (https://github.com/CCPPETMR/SIRF-SuperBuild/issues/167)
+   # -boost -hdf5 -swig
+   env: EXTRA_BUILD_FLAGS="-DUSE_SYSTEM_Boost=OFF -DUSE_SYSTEM_HDF5=OFF -DUSE_SYSTEM_SWIG=OFF" MATRIX_EVAL="CC=gcc CXX=g++" PYMVER=2
  - os: osx
    # -boost -hdf5 -swig
    python: 3

--- a/.travis.yml
+++ b/.travis.yml
@@ -52,7 +52,7 @@ matrix:
  - os: osx
    # -boost -hdf5 -swig
    python: 3
-   env: EXTRA_BUILD_FLAGS="-DUSE_SYSTEM_Boost=OFF -DUSE_SYSTEM_HDF5=ON -DUSE_SYSTEM_SWIG=ON" MATRIX_EVAL="CC=gcc CXX=g++" PYMVER=3
+   env: EXTRA_BUILD_FLAGS="-DUSE_SYSTEM_Boost=OFF -DUSE_SYSTEM_HDF5=OFF -DUSE_SYSTEM_FFTW3=ON -DUSE_SYSTEM_SWIG=ON" MATRIX_EVAL="CC=gcc CXX=g++" PYMVER=3
  - os: osx
    python: 2.7
    # +DEVEL +boost -hdf5 +swig

--- a/.travis.yml
+++ b/.travis.yml
@@ -174,9 +174,10 @@ before_install:
         brew install ace
         brew install swig
         brew install ccache
-        string='My long string'
-        if [[ $BUILD_FLAGS == *"SYSTEM_FFTW3=ON"* ]]; then
+        if [[ $EXTRA_BUILD_FLAGS == *"SYSTEM_FFTW3=ON"* ]]; then
             brew install fftw
+        else
+            echo "Not installing FFTW as we are building it"
         fi
         # need curl to get pip and more recent cmake
         brew install curl

--- a/.travis.yml
+++ b/.travis.yml
@@ -174,6 +174,10 @@ before_install:
         brew install ace
         brew install swig
         brew install ccache
+        string='My long string'
+        if [[ $BUILD_FLAGS == *"SYSTEM_FFTW3=ON"* ]]; then
+            brew install fftw
+        fi
         # need curl to get pip and more recent cmake
         brew install curl
         #brew install cmake # already present

--- a/SuperBuild/External_Boost_buildboost.cmake
+++ b/SuperBuild/External_Boost_buildboost.cmake
@@ -23,7 +23,7 @@ if(WIN32)
   # TODO: would be better to use a variable but for some reason KT cannot pass the variable to the execute_process
   # without strange error messages of b2
   
-  execute_process(COMMAND ./b2 --with-system --with-filesystem --with-thread --with-program_options --with-chrono --with-date_time --with-atomic  --with-timer install --prefix=${BOOST_INSTALL_DIR}
+  execute_process(COMMAND ./b2 --with-system --with-filesystem --with-thread --with-program_options --with-chrono --with-date_time --with-atomic  --with-timer --with-test install --prefix=${BOOST_INSTALL_DIR}
     WORKING_DIRECTORY ${BUILD_DIR} RESULT_VARIABLE build_result)
 
 else(WIN32)

--- a/SuperBuild/External_Boost_configureboost.cmake
+++ b/SuperBuild/External_Boost_configureboost.cmake
@@ -24,7 +24,7 @@ if(WIN32)
 else()
   message("Build dir is : ${BUILD_DIR}")
   execute_process(COMMAND ./bootstrap.sh --prefix=${BOOST_INSTALL_DIR}
-    --with-libraries=system,filesystem,thread,program_options,chrono,date_time,atomic,timer,regex
+    --with-libraries=system,filesystem,thread,program_options,chrono,date_time,atomic,timer,regex,test
     #--with-libraries=system,thread,program_options,log,math...
     #--without-libraries=atomic...
 

--- a/version_config.cmake
+++ b/version_config.cmake
@@ -143,8 +143,7 @@ else()
 
   ## STIR
   set(DEFAULT_STIR_URL https://github.com/UCL/STIR )
-  set(DEFAULT_STIR_TAG a5fefe741f97a65de95ac51ac612719f5000ac47)
-#  set(DEFAULT_STIR_TAG 9e62872c74cbcea1886d107cb22ab28a5a33083e)
+  set(DEFAULT_STIR_TAG fd3a7576a11930856d6af50d217f17d4848c2bff)
 
   ## Gadgetron
   set(DEFAULT_Gadgetron_URL https://github.com/gadgetron/gadgetron )

--- a/version_config.cmake
+++ b/version_config.cmake
@@ -96,10 +96,19 @@ set(DEFAULT_SIRF_URL https://github.com/CCPPETMR/SIRF )
 if (DEVEL_BUILD)
 
   # Gadgetron needs 1.65
-  set(Boost_VERSION 1.65.1)
-  set(Boost_REQUIRED_VERSION 1.65.1)
-  set(Boost_URL http://downloads.sourceforge.net/project/boost/boost/1.65.1/boost_1_65_1.zip)
-  set(Boost_MD5 9824a7a3e25c9d4fdf2def07bce8651c)
+  if (APPLE) # really should be checking for CLang
+      # Boost 1.65 contains a bug for recent Clang https://github.com/CCPPETMR/SIRF-SuperBuild/issues/170
+      set(Boost_VERSION 1.68.0)
+      set(Boost_REQUIRED_VERSION 1.66.0)
+      set(Boost_URL http://downloads.sourceforge.net/project/boost/boost/${Boost_VERSION}/boost_1_68_0.zip)
+      set(Boost_MD5 f4096c4583947b0eb103c8539f1623a3)
+  else()
+       # Use version in Ubuntu 18.04
+       set(Boost_VERSION 1.65.1)
+       set(Boost_REQUIRED_VERSION 1.65.1)
+       set(Boost_URL http://downloads.sourceforge.net/project/boost/boost/${Boost_VERSION}/boost_1_65_1.zip)
+       set(Boost_MD5 9824a7a3e25c9d4fdf2def07bce8651c)
+  endif()
 
   set (DEFAULT_SIRF_TAG origin/master)
   ## STIR


### PR DESCRIPTION
ISMRMRD searches for unit_test. As we don't build it, it might find a system version, which would then create conflicts between boost versions (as in #165)