### PR TITLE
If building own version of boost, try to minimise looking for other versions

### DIFF
--- a/SuperBuild.cmake
+++ b/SuperBuild.cmake
@@ -178,14 +178,6 @@ if (USE_ITK)
   option(USE_SYSTEM_ITK "Build using an external version of ITK" OFF)
 endif()
 
-# Boost
-if (NOT USE_SYSTEM_Boost)
-  set(NO_CONFIG ON)
-  set(NO_SYSTEM_PATHS ON)
-  mark_as_superbuild(NO_CONFIG)
-  mark_as_superbuild(NO_SYSTEM_PATHS)
-endif()
-
 ## build list of dependencies, based on options above
 # first set to empty
 set(${PRIMARY_PROJECT_NAME}_DEPENDENCIES)

--- a/SuperBuild.cmake
+++ b/SuperBuild.cmake
@@ -178,6 +178,14 @@ if (USE_ITK)
   option(USE_SYSTEM_ITK "Build using an external version of ITK" OFF)
 endif()
 
+# Boost
+if (NOT USE_SYSTEM_Boost)
+  set(NO_CONFIG ON)
+  set(NO_SYSTEM_PATHS ON)
+  mark_as_superbuild(NO_CONFIG)
+  mark_as_superbuild(NO_SYSTEM_PATHS)
+endif()
+
 ## build list of dependencies, based on options above
 # first set to empty
 set(${PRIMARY_PROJECT_NAME}_DEPENDENCIES)

--- a/SuperBuild/External_Boost.cmake
+++ b/SuperBuild/External_Boost.cmake
@@ -40,6 +40,12 @@ set(${proj}_TMP_DIR "${SUPERBUILD_WORK_DIR}/builds/${proj}/tmp" )
 if(NOT ( DEFINED "USE_SYSTEM_${externalProjName}" AND "${USE_SYSTEM_${externalProjName}}" ) )
   message(STATUS "${__indent}Adding project ${proj}")
 
+  # If building own version of boost, try to minimise looking for other versions
+  set(Boost_NO_BOOST_CMAKE ON)
+  set(Boost_NO_SYSTEM_PATHS ON)
+  mark_as_superbuild(Boost_NO_BOOST_CMAKE)
+  mark_as_superbuild(Boost_NO_SYSTEM_PATHS)
+
   ### --- Project specific additions here
   set(Boost_Install_Dir ${SUPERBUILD_INSTALL_DIR})
   set(Boost_Configure_Script ${CMAKE_CURRENT_LIST_DIR}/External_Boost_configureboost.cmake)


### PR DESCRIPTION
Should be ok, but untested