### PR TITLE
Travis changes for OSX and docker

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,9 +44,9 @@ matrix:
    # +boost -hdf5 -swig
    env: EXTRA_BUILD_FLAGS="-DUSE_SYSTEM_Boost=ON -DUSE_SYSTEM_HDF5=OFF -DUSE_SYSTEM_SWIG=OFF" MATRIX_EVAL="CC=gcc CXX=g++" PYMVER=2
  - os: osx
-   # +boost -hdf5 +fftw3 +swig
+   # +boost +fftw3 -hdf5 -swig
    python: 3
-   env: EXTRA_BUILD_FLAGS="-DUSE_SYSTEM_Boost=ON -DUSE_SYSTEM_HDF5=OFF -DUSE_SYSTEM_FFTW3=ON -DUSE_SYSTEM_SWIG=ON" MATRIX_EVAL="CC=gcc CXX=g++" PYMVER=3
+   env: EXTRA_BUILD_FLAGS="-DUSE_SYSTEM_Boost=ON -DUSE_SYSTEM_FFTW3=ON -DUSE_SYSTEM_HDF5=OFF -DUSE_SYSTEM_SWIG=OFF" MATRIX_EVAL="CC=gcc CXX=g++" PYMVER=3
  - os: osx
    python: 2.7
    # +DEVEL +boost -hdf5 +swig

--- a/.travis.yml
+++ b/.travis.yml
@@ -65,12 +65,12 @@ matrix:
    # +boost +itk -hdf5 +swig
    env: EXTRA_BUILD_FLAGS="-DUSE_SYSTEM_Boost=ON -DUSE_ITK=ON -DUSE_SYSTEM_HDF5=OFF -DUSE_SYSTEM_SWIG=ON" MATRIX_EVAL="CC=gcc CXX=g++" PYMVER=2
  # docker
- - os: linux
-   # +armadillo +boost +fftw3 +hdf5 +siemens_to_ismrmrd +swig
-   env: DOCKER_BUILD=1
- - os: linux
-   # +DEVEL +armadillo +boost +fftw3 +hdf5 +siemens_to_ismrmrd +swig
-   env: DOCKER_BUILD=DEVEL
+ #- os: linux
+ #  # +armadillo +boost +fftw3 +hdf5 +siemens_to_ismrmrd +swig
+ #  env: DOCKER_BUILD=1
+ #- os: linux
+ #  # +DEVEL +armadillo +boost +fftw3 +hdf5 +siemens_to_ismrmrd +swig
+ #  env: DOCKER_BUILD=DEVEL
 
 env:
  global:

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,18 +21,6 @@ language: cpp
 #       i.e. -boost == -DUSE_SYSTEM_Boost=OFF, which means that Boost will be built.
 matrix:
  include:
- - os: linux
-   python: 3
-   # -boost -itk +fftw3 +hdf5 +ace +niftyreg
-   env: EXTRA_BUILD_FLAGS="-DUSE_SYSTEM_Boost=OFF -DUSE_ITK=OFF -DUSE_SYSTEM_FFTW3=ON -DUSE_SYSTEM_HDF5=ON -DUSE_SYSTEM_ACE=ON -DUSE_NiftyReg=ON" MATRIX_EVAL="CC=gcc-6 CXX=g++-6" PYMVER=3
- - os: linux
-   python: 2.7
-   # -boost -itk +fftw3 +hdf5 +ace +niftyreg
-   env: EXTRA_BUILD_FLAGS="-DUSE_SYSTEM_Boost=OFF -DUSE_ITK=OFF -DUSE_SYSTEM_FFTW3=ON -DUSE_SYSTEM_HDF5=ON -DUSE_SYSTEM_ACE=ON -DUSE_NiftyReg=ON" MATRIX_EVAL="CC=gcc-6 CXX=g++-6" PYMVER=3
- - os: linux
-   python: 3
-   # -boost -itk +fftw3 +hdf5 +ace
-   env: EXTRA_BUILD_FLAGS="-DUSE_SYSTEM_Boost=OFF -DUSE_ITK=OFF -DUSE_SYSTEM_FFTW3=ON -DUSE_SYSTEM_HDF5=ON -DUSE_SYSTEM_ACE=ON" MATRIX_EVAL="CC=gcc-6 CXX=g++-6" PYMVER=3
  # linux g{cc,++}-6 py{27,3}
  - os: linux
    python: 3

--- a/.travis.yml
+++ b/.travis.yml
@@ -292,7 +292,7 @@ script:
       ./INSTALL/bin/gadgetron >& gadgetron.log&
       # print for debugging
       cat builds/SIRF/build/CMakeCache.txt
-      ctest -VV; test_fail=$?
+      ctest --output-on-failure; test_fail=$?
       # print for debugging
       cat builds/SIRF/build/Testing/Temporary/LastTest.log
       # may exceed 4MB travis log limit

--- a/.travis.yml
+++ b/.travis.yml
@@ -293,11 +293,15 @@ script:
       # print for debugging
       cat builds/SIRF/build/CMakeCache.txt
       ctest --output-on-failure; test_fail=$?
-      # print for debugging
-      cat builds/SIRF/build/Testing/Temporary/LastTest.log
-      # may exceed 4MB travis log limit
-      cat gadgetron.log
-      [[ $test_fail -ne 0 ]] || travis_terminate $test_fail
+      # echo "----------- Killing gadgetron server"
+      # killall gadgetron
+      if [[ $test_fail -ne 0 ]]; then
+        #echo "----------- Test output"
+        # cat builds/SIRF/build/Testing/Temporary/LastTest.log
+        echo "----------- Last 70 lines of gadgetron.log"
+        tail -n 70 gadgetron.log
+        travis_terminate $test_fail
+      fi
     fi
 
 # post to slack.com

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,12 +32,12 @@ matrix:
    env: EXTRA_BUILD_FLAGS="-DUSE_SYSTEM_Boost=OFF -DUSE_SYSTEM_FFTW3=ON -DUSE_SYSTEM_HDF5=ON -DBUILD_siemens_to_ismrmrd=ON -DUSE_SYSTEM_SWIG=ON -DUSE_SYSTEM_ACE=ON" MATRIX_EVAL="CC=gcc-6 CXX=g++-6" PYMVER=2
  - os: linux
    python: 3
-   # +DEVEL -boost -hdf5 -fftw3 +siemens_to_ismrmrd
-   env: EXTRA_BUILD_FLAGS="-DDEVEL_BUILD=ON -DUSE_SYSTEM_Boost=OFF -DUSE_SYSTEM_HDF5=OFF -DUSE_SYSTEM_FFTW3=OFF -DBUILD_siemens_to_ismrmrd=ON" MATRIX_EVAL="CC=gcc-6 CXX=g++-6" PYMVER=3
+   # +DEVEL -boost -hdf5 -fftw3 +ace +siemens_to_ismrmrd
+   env: EXTRA_BUILD_FLAGS="-DDEVEL_BUILD=ON -DUSE_SYSTEM_Boost=OFF -DUSE_SYSTEM_HDF5=OFF -DUSE_SYSTEM_FFTW3=OFF -DUSE_SYSTEM_ACE=ON -DBUILD_siemens_to_ismrmrd=ON" MATRIX_EVAL="CC=gcc-6 CXX=g++-6" PYMVER=3
  - os: linux
    python: 2.7
-   # +DEVEL -boost -fftw3 -hdf5 -swig
-   env: EXTRA_BUILD_FLAGS="-DDEVEL_BUILD=ON -DUSE_SYSTEM_Boost=OFF -DUSE_SYSTEM_FFTW3=OFF -DUSE_SYSTEM_HDF5=OFF -DUSE_SYSTEM_SWIG=OFF" MATRIX_EVAL="CC=gcc-6 CXX=g++-6" PYMVER=2
+   # +DEVEL -boost -fftw3 -hdf5 -swig +ace
+   env: EXTRA_BUILD_FLAGS="-DDEVEL_BUILD=ON -DUSE_SYSTEM_Boost=OFF -DUSE_SYSTEM_FFTW3=OFF -DUSE_SYSTEM_HDF5=OFF -DUSE_SYSTEM_ACE=ON -DUSE_SYSTEM_SWIG=OFF" MATRIX_EVAL="CC=gcc-6 CXX=g++-6" PYMVER=2
  # osx g{cc,++} py{27,36}
  - os: osx
    python: 2.7


### PR DESCRIPTION
- OSX builds had a weird time-out at the end of all the testing when doing `cat` of the log files, the Travis log file contained only the first part of (usually) the gadgetron.log and then a time-out message that 10mins went past without output. As this doesn't happen in the SIRF Travis build, the only explanation that I can see is some strange limitation of the subshell feature of OSX. This PR therefore only writes log files when something went wrong.

- Disabled docker builds for now, pending fixes #195 

- Also synced with (most of) the SIRF .travis.yml.