### PR TITLE
update NiftyReg version for case-sensitive systems

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,8 @@
 # ChangeLog
 
+## v2.0.1
+- Switch NiftyReg remote from `rijobro` to `KCL-BMEIS` (following the acceptance of one of our PRs to their code).
+
 
 ## v2.0.0
 - Added CMake Variable `Gadgetron_USE_MKL` to allow Gadgetron build with MKL if available

--- a/version_config.cmake
+++ b/version_config.cmake
@@ -96,9 +96,9 @@ set(ITK_URL https://itk.org/ITK.git)
 set(ITK_TAG v4.13.1)
 
 ## NIFTYREG
-set(DEFAULT_NIFTYREG_URL https://github.com/rijobro/niftyreg.git )
-set(DEFAULT_NIFTYREG_TAG 22f24db1113973507689aeabbc3f17ddeca1d7f6 )
-set(DEFAULT_NIFTYREG_REQUIRED_VERSION 1.5.61)
+set(DEFAULT_NIFTYREG_URL https://github.com/KCL-BMEIS/niftyreg.git )
+set(DEFAULT_NIFTYREG_TAG 99d584e2b8ea0bffe7e65e40c8dc818751782d92 )
+set(DEFAULT_NIFTYREG_REQUIRED_VERSION 1.5.68)
 
 ## ISMRMRD
 set(DEFAULT_ISMRMRD_URL https://github.com/ismrmrd/ismrmrd )


### PR DESCRIPTION
Now that `NIFTYREGConfig.cmake` is case sensitive (https://github.com/KCL-BMEIS/niftyreg/pull/53), switch remote back from rijobro fork to KCL fork.