### PR TITLE
clone and install sirf-contrib

### DIFF
--- a/SuperBuild.cmake
+++ b/SuperBuild.cmake
@@ -177,6 +177,7 @@ option(BUILD_petmr_rd_tools "Build petmr_rd_tools" OFF)
 option(BUILD_CIL "Build CCPi CIL Modules and ASTRA engine" OFF)
 option(BUILD_CIL_LITE "Build CCPi CIL Modules" OFF)
 option(BUILD_NIFTYREG "Build NIFTYREG" ON)
+option(BUILD_SIRF_Contribs "Build SIRF-Contribs" ON)
 
 option(BUILD_SIRF_Registration "Build SIRFS's registration functionality" ${BUILD_NIFTYREG})
 if (BUILD_SIRF_Registration AND NOT BUILD_NIFTYREG)
@@ -252,6 +253,10 @@ endif()
 
 if (BUILD_SIRF_Registration)
   list(APPEND ${PRIMARY_PROJECT_NAME}_DEPENDENCIES NIFTYREG)
+endif()
+
+if (BUILD_SIRF_Contribs)
+  list(APPEND ${PRIMARY_PROJECT_NAME}_DEPENDENCIES SIRF-Contribs)
 endif()
 
 ExternalProject_Include_Dependencies(${proj} DEPENDS_VAR ${PRIMARY_PROJECT_NAME}_DEPENDENCIES)

--- a/SuperBuild/External_SIRF-Contribs.cmake
+++ b/SuperBuild/External_SIRF-Contribs.cmake
@@ -1,0 +1,77 @@
+#========================================================================
+# Author: Edoardo Pasca
+# Copyright 2018-2019 STFC
+#
+# This file is part of the CCP PETMR Synergistic Image Reconstruction Framework (SIRF) SuperBuild.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+#=========================================================================
+
+#This needs to be unique globally
+set(proj SIRF-Contribs)
+
+# Include dependent projects if any
+ExternalProject_Include_Dependencies(${proj} DEPENDS_VAR ${proj}_DEPENDENCIES)
+
+# Set external name (same as internal for now)
+set(externalProjName ${proj})
+
+set(${proj}_SOURCE_DIR "${SOURCE_ROOT_DIR}/${proj}" )
+set(${proj}_BINARY_DIR "${SUPERBUILD_WORK_DIR}/builds/${proj}/build" )
+set(${proj}_DOWNLOAD_DIR "${SUPERBUILD_WORK_DIR}/downloads/${proj}" )
+set(${proj}_STAMP_DIR "${SUPERBUILD_WORK_DIR}/builds/${proj}/stamp" )
+set(${proj}_TMP_DIR "${SUPERBUILD_WORK_DIR}/builds/${proj}/tmp" )
+
+if(NOT ( DEFINED "USE_SYSTEM_${externalProjName}" AND "${USE_SYSTEM_${externalProjName}}" ) )
+  message(STATUS "${__indent}Adding project ${proj}")
+
+  # conda build should never get here
+  if("${PYTHON_STRATEGY}" STREQUAL "PYTHONPATH")
+    # in case of PYTHONPATH it is sufficient to copy the files to the 
+    # $PYTHONPATH directory
+    ExternalProject_Add(${proj}
+      ${${proj}_EP_ARGS}
+      GIT_REPOSITORY ${${proj}_URL}
+      GIT_TAG ${${proj}_TAG}
+      SOURCE_DIR ${${proj}_SOURCE_DIR}
+      BINARY_DIR ${${proj}_BINARY_DIR}
+      DOWNLOAD_DIR ${${proj}_DOWNLOAD_DIR}
+      STAMP_DIR ${${proj}_STAMP_DIR}
+      TMP_DIR ${${proj}_TMP_DIR}
+      INSTALL_DIR ${libcilreg_Install_Dir}
+    
+      CONFIGURE_COMMAND ""
+      BUILD_COMMAND ""
+      INSTALL_COMMAND ${CMAKE_COMMAND} -E copy_directory ${${proj}_SOURCE_DIR}/src/Python/sirf/ ${PYTHON_DEST}/sirf
+    )
+
+  else()
+    # if SETUP_PY one can launch the conda build.sh script setting 
+    # the appropriate variables.
+    message(FATAL_ERROR "Only PYTHONPATH install method is currently supported")
+  endif()
+
+
+  set(${proj}_ROOT        ${${proj}_SOURCE_DIR})
+  set(${proj}_INCLUDE_DIR ${${proj}_SOURCE_DIR})
+
+else()
+  ExternalProject_Add_Empty(${proj} DEPENDS "${${proj}_DEPENDENCIES}"
+    SOURCE_DIR ${${proj}_SOURCE_DIR}
+    BINARY_DIR ${${proj}_BINARY_DIR}
+    DOWNLOAD_DIR ${${proj}_DOWNLOAD_DIR}
+    STAMP_DIR ${${proj}_STAMP_DIR}
+    TMP_DIR ${${proj}_TMP_DIR}
+  )
+endif()

--- a/version_config.cmake
+++ b/version_config.cmake
@@ -142,6 +142,10 @@ set(DEFAULT_TomoPhantom_TAG v1.4)
 set(DEFAULT_NIFTYPET_URL https://github.com/pjmark/NIPET )
 set(DEFAULT_NIFTYPET_TAG 70b97da0a4eea9445e34831f7393947a37bc77e7)
 
+## SIRF-Contribs
+set(DEFAULT_SIRF-Contribs_URL https://github.com/CCPPETMR/SIRF-Contribs )
+set(DEFAULT_SIRF-Contribs_TAG 29ab88bb5a0032daa464c2617a49ba6881813902 )
+
 option (DEVEL_BUILD "Developer Build" OFF)
 mark_as_advanced(DEVEL_BUILD)
 
@@ -264,6 +268,9 @@ set(NIFTYREG_TAG ${DEFAULT_NIFTYREG_TAG} CACHE STRING ON)
 set(NIFTYPET_URL ${DEFAULT_NIFTYPET_URL} CACHE STRING ON)
 set(NIFTYPET_TAG ${DEFAULT_NIFTYPET_TAG} CACHE STRING ON)
 
+set(SIRF-Contribs_URL ${DEFAULT_SIRF-Contribs_URL} CACHE STRING ON)
+set(SIRF-Contribs_TAG ${DEFAULT_SIRF-Contribs_TAG} CACHE STRING ON)
+
 mark_as_advanced(SIRF_URL SIRF_TAG STIR_URL STIR_TAG
   Gadgetron_URL Gadgetron_TAG
   siemens_to_ismrmrd_URL siemens_to_ismrmrd_TAG
@@ -275,4 +282,5 @@ mark_as_advanced(SIRF_URL SIRF_TAG STIR_URL STIR_TAG
   CCPi-FrameworkPlugins_URL CCPi-FrameworkPlugins_TAG
   CCPi-Regularisation-Toolkit_URL CCPi-Regularisation-Toolkit_TAG
   NIFTYPET_URL NIFTYPET_TAG
+  SIRF-Contribs_URL SIRF-Contribs_TAG
 )


### PR DESCRIPTION
use with e.g., `from sirf.contrib.kcl import Prior`
fixes #263