### PR TITLE
[TRAVIS] OSX: find latest openblas version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -373,7 +373,7 @@ before_install:
      brew update
      BUILD_FLAGS="$BUILD_FLAGS -DSHARED_LIBS_ABS_PATH=ON"
      brew install openblas
-     # Let CMake find this openblas version (note: we use /usr/local/opt/openblas symlink to get the most recent brew version)
+     # Let CMake find this blas version (note: we use /usr/local/opt/openblas symlink to get the most recent brew version)
      EXTRA_BUILD_FLAGS="$EXTRA_BUILD_FLAGS -DCBLAS_INCLUDE_DIR=/usr/local/opt/openblas/include -DCBLAS_LIBRARY=/usr/local/opt/openblas/lib/libblas.dylib"
      if [ $PYMVER == 2 ]; then
        PYINST=/System/Library/Frameworks/Python.framework/Versions/$PYMVER.7
@@ -422,7 +422,6 @@ before_install:
        #export PATH="$PWD/cmake/bin:$PATH"
      )
    elif [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
-     exit 1 # KTTRAVIS
      PY_EXE=python$PYMVER
      if [[ -z "$DOCKER_BUILD" ]]; then
        curl -o cmake.tgz -L https://github.com/Kitware/CMake/releases/download/v3.13.4/cmake-3.13.4-Linux-x86_64.tar.gz

--- a/.travis.yml
+++ b/.travis.yml
@@ -422,10 +422,12 @@ before_install:
      # Get openblas version (note: do this after all brew operations in case one of them updates blas)
      blas_ver=$(brew list --versions openblas)
      blas_ver=${blas_ver#"openblas "}
+     ls -R /usr/local/Cellar/openblas/${blas_ver}/
      EXTRA_BUILD_FLAGS="$EXTRA_BUILD_FLAGS -DCBLAS_INCLUDE_DIR=/usr/local/Cellar/openblas/${blas_ver}/include -DCBLAS_LIBRARY=/usr/local/Cellar/openblas/${blas_ver}/lib/libblas.dylib"
 
    elif [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
-     PY_EXE=python$PYMVER
+exit 1# KTTRAVIS
+PY_EXE=python$PYMVER
      if [[ -z "$DOCKER_BUILD" ]]; then
        curl -o cmake.tgz -L https://github.com/Kitware/CMake/releases/download/v3.13.4/cmake-3.13.4-Linux-x86_64.tar.gz
        tar xzf cmake.tgz && rm cmake.tgz
@@ -476,6 +478,7 @@ before_install:
 
 install:
 - $PY_EXE -m pip install --user --only-binary=numpy,scipy,matplotlib numpy scipy matplotlib
+- echo cmake flags: $BUILD_FLAGS $EXTRA_BUILD_FLAGS
 - cmake $BUILD_FLAGS $EXTRA_BUILD_FLAGS .
 # Job may timeout (>50min) if no ccache, otherwise should be <1min:
 - make

--- a/.travis.yml
+++ b/.travis.yml
@@ -426,8 +426,8 @@ before_install:
      EXTRA_BUILD_FLAGS="$EXTRA_BUILD_FLAGS -DCBLAS_INCLUDE_DIR=/usr/local/Cellar/openblas/${blas_ver}/include -DCBLAS_LIBRARY=/usr/local/Cellar/openblas/${blas_ver}/lib/libblas.dylib"
 
    elif [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
-exit 1 # KTTRAVIS
-PY_EXE=python$PYMVER
+     exit 1 # KTTRAVIS
+     PY_EXE=python$PYMVER
      if [[ -z "$DOCKER_BUILD" ]]; then
        curl -o cmake.tgz -L https://github.com/Kitware/CMake/releases/download/v3.13.4/cmake-3.13.4-Linux-x86_64.tar.gz
        tar xzf cmake.tgz && rm cmake.tgz

--- a/.travis.yml
+++ b/.travis.yml
@@ -420,10 +420,14 @@ before_install:
        #export PATH="$PWD/cmake/bin:$PATH"
      )
      # Get openblas version (note: do this after all brew operations in case one of them updates blas)
-     blas_ver=$(brew list --versions openblas)
-     blas_ver=${blas_ver#"openblas "}
-     ls -R /usr/local/Cellar/openblas/${blas_ver}/
-     EXTRA_BUILD_FLAGS="$EXTRA_BUILD_FLAGS -DCBLAS_INCLUDE_DIR=/usr/local/Cellar/openblas/${blas_ver}/include -DCBLAS_LIBRARY=/usr/local/Cellar/openblas/${blas_ver}/lib/libblas.dylib"
+     ls -l /usr/local/opt/
+     ls -l /usr/local/opt/python
+     ls -R /usr/local/opt/openblas
+     
+     #blas_ver=$(brew list --versions openblas)
+     #blas_ver=${blas_ver#"openblas "}
+     #ls -R /usr/local/Cellar/openblas/${blas_ver}/
+     EXTRA_BUILD_FLAGS="$EXTRA_BUILD_FLAGS -DCBLAS_INCLUDE_DIR=/usr/local/opt/openblas/include -DCBLAS_LIBRARY=/usr/local/opt/openblas/lib/libblas.dylib"
 
    elif [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
      exit 1 # KTTRAVIS

--- a/.travis.yml
+++ b/.travis.yml
@@ -471,10 +471,10 @@ before_install:
 - BUILD_FLAGS="$BUILD_FLAGS -DPYVER=$PYMVER"
 - BUILD_FLAGS="$BUILD_FLAGS -DCMAKE_C_COMPILER='$(which $CC)' -DCMAKE_CXX_COMPILER='$(which $CXX)'"
 - cmake --version
+- echo "cmake flags $BUILD_FLAGS $EXTRA_BUILD_FLAGS"
 
 install:
 - $PY_EXE -m pip install --user --only-binary=numpy,scipy,matplotlib numpy scipy matplotlib
-- echo "cmake flags: $BUILD_FLAGS $EXTRA_BUILD_FLAGS"
 - cmake $BUILD_FLAGS $EXTRA_BUILD_FLAGS .
 # Job may timeout (>50min) if no ccache, otherwise should be <1min:
 - make

--- a/.travis.yml
+++ b/.travis.yml
@@ -373,10 +373,6 @@ before_install:
      brew update
      BUILD_FLAGS="$BUILD_FLAGS -DSHARED_LIBS_ABS_PATH=ON"
      brew install openblas
-     # Get openblas version
-     blas_ver=$(brew list --versions openblas)
-     blas_ver=${blas_ver#"openblas "}
-     EXTRA_BUILD_FLAGS="$EXTRA_BUILD_FLAGS -DCBLAS_INCLUDE_DIR=/usr/local/Cellar/openblas/${blas_ver}/include -DCBLAS_LIBRARY=/usr/local/Cellar/openblas/${blas_ver}/lib/libblas.dylib"
      if [ $PYMVER == 2 ]; then
        PYINST=/System/Library/Frameworks/Python.framework/Versions/$PYMVER.7
        PY_EXE=$PYINST/bin/python2.7
@@ -423,6 +419,11 @@ before_install:
        #mv cmake-*/CMake.app/Contents/* cmake
        #export PATH="$PWD/cmake/bin:$PATH"
      )
+     # Get openblas version (note: do this after all brew operations in case one of them updates blas)
+     blas_ver=$(brew list --versions openblas)
+     blas_ver=${blas_ver#"openblas "}
+     EXTRA_BUILD_FLAGS="$EXTRA_BUILD_FLAGS -DCBLAS_INCLUDE_DIR=/usr/local/Cellar/openblas/${blas_ver}/include -DCBLAS_LIBRARY=/usr/local/Cellar/openblas/${blas_ver}/lib/libblas.dylib"
+
    elif [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
      PY_EXE=python$PYMVER
      if [[ -z "$DOCKER_BUILD" ]]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -373,6 +373,8 @@ before_install:
      brew update
      BUILD_FLAGS="$BUILD_FLAGS -DSHARED_LIBS_ABS_PATH=ON"
      brew install openblas
+     # Let CMake find this openblas version (note: we use /usr/local/opt/openblas symlink to get the most recent brew version)
+     EXTRA_BUILD_FLAGS="$EXTRA_BUILD_FLAGS -DCBLAS_INCLUDE_DIR=/usr/local/opt/openblas/include -DCBLAS_LIBRARY=/usr/local/opt/openblas/lib/libblas.dylib"
      if [ $PYMVER == 2 ]; then
        PYINST=/System/Library/Frameworks/Python.framework/Versions/$PYMVER.7
        PY_EXE=$PYINST/bin/python2.7
@@ -419,16 +421,6 @@ before_install:
        #mv cmake-*/CMake.app/Contents/* cmake
        #export PATH="$PWD/cmake/bin:$PATH"
      )
-     # Get openblas version (note: do this after all brew operations in case one of them updates blas)
-     ls -l /usr/local/opt/
-     ls -l /usr/local/opt/python
-     ls -R /usr/local/opt/openblas
-     
-     #blas_ver=$(brew list --versions openblas)
-     #blas_ver=${blas_ver#"openblas "}
-     #ls -R /usr/local/Cellar/openblas/${blas_ver}/
-     EXTRA_BUILD_FLAGS="$EXTRA_BUILD_FLAGS -DCBLAS_INCLUDE_DIR=/usr/local/opt/openblas/include -DCBLAS_LIBRARY=/usr/local/opt/openblas/lib/libblas.dylib"
-
    elif [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
      exit 1 # KTTRAVIS
      PY_EXE=python$PYMVER
@@ -482,7 +474,7 @@ before_install:
 
 install:
 - $PY_EXE -m pip install --user --only-binary=numpy,scipy,matplotlib numpy scipy matplotlib
-- echo cmake flags: $BUILD_FLAGS $EXTRA_BUILD_FLAGS
+- echo "cmake flags: $BUILD_FLAGS $EXTRA_BUILD_FLAGS"
 - cmake $BUILD_FLAGS $EXTRA_BUILD_FLAGS .
 # Job may timeout (>50min) if no ccache, otherwise should be <1min:
 - make

--- a/.travis.yml
+++ b/.travis.yml
@@ -426,7 +426,7 @@ before_install:
      EXTRA_BUILD_FLAGS="$EXTRA_BUILD_FLAGS -DCBLAS_INCLUDE_DIR=/usr/local/Cellar/openblas/${blas_ver}/include -DCBLAS_LIBRARY=/usr/local/Cellar/openblas/${blas_ver}/lib/libblas.dylib"
 
    elif [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
-exit 1# KTTRAVIS
+exit 1 # KTTRAVIS
 PY_EXE=python$PYMVER
      if [[ -z "$DOCKER_BUILD" ]]; then
        curl -o cmake.tgz -L https://github.com/Kitware/CMake/releases/download/v3.13.4/cmake-3.13.4-Linux-x86_64.tar.gz


### PR DESCRIPTION
`brew` can change versions on packages due to dependencies etc. So we need to find the BLAS version
just before starting to build.

Fixes #356