### PR TITLE
Cil devel build tag

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -83,8 +83,8 @@ jobs:
       - *addons_apt_packages
       - g++-6
    python: 3.6
-   name: py36 gcc6 +xenial -boost +fftw3 +hdf5 +ace
-   env: EXTRA_BUILD_FLAGS="-DUSE_SYSTEM_Boost=OFF -DUSE_SYSTEM_FFTW3=ON -DUSE_SYSTEM_HDF5=ON -DUSE_SYSTEM_ACE=ON -DBUILD_CIL=OFF" MATRIX_EVAL="CC=gcc-6 CXX=g++-6" PYMVER=3
+   name: py36 gcc6 +xenial -boost +fftw3 +hdf5 +ace +cil
+   env: EXTRA_BUILD_FLAGS="-DUSE_SYSTEM_Boost=OFF -DUSE_SYSTEM_FFTW3=ON -DUSE_SYSTEM_HDF5=ON -DUSE_SYSTEM_ACE=ON -DBUILD_CIL=ON" MATRIX_EVAL="CC=gcc-6 CXX=g++-6" PYMVER=3
 
  # trusty disabled
  # This fails since Feb 2020 due to Python3 being 3.4.3, even though we ask for more recent.
@@ -104,20 +104,20 @@ jobs:
 # current linux
  - os: linux
    python: 3.6
-   name: py36 -boost +fftw3 +hdf5 +ace
-   env: EXTRA_BUILD_FLAGS="-DUSE_SYSTEM_Boost=OFF -DUSE_SYSTEM_FFTW3=ON -DUSE_SYSTEM_HDF5=ON -DUSE_SYSTEM_ACE=ON -DBUILD_CIL=OFF" PYMVER=3
+   name: py36 -boost +fftw3 +hdf5 +ace +cil
+   env: EXTRA_BUILD_FLAGS="-DUSE_SYSTEM_Boost=OFF -DUSE_SYSTEM_FFTW3=ON -DUSE_SYSTEM_HDF5=ON -DUSE_SYSTEM_ACE=ON -DBUILD_CIL=ON" PYMVER=3
  - os: linux
    python: 2.7
-   name: py27 -boost +fftw3 +hdf5 +ace
-   env: EXTRA_BUILD_FLAGS="-DUSE_SYSTEM_Boost=OFF -DUSE_SYSTEM_FFTW3=ON -DUSE_SYSTEM_HDF5=ON -DUSE_SYSTEM_ACE=ON -DBUILD_CIL=OFF" PYMVER=2
+   name: py27 -boost +fftw3 +hdf5 +ace +cil
+   env: EXTRA_BUILD_FLAGS="-DUSE_SYSTEM_Boost=OFF -DUSE_SYSTEM_FFTW3=ON -DUSE_SYSTEM_HDF5=ON -DUSE_SYSTEM_ACE=ON -DBUILD_CIL=ON" PYMVER=2
  - os: linux
    python: 2.7
-   name: py27 -boost +fftw3 +hdf5 +ace
-   env: EXTRA_BUILD_FLAGS="-DUSE_SYSTEM_Boost=OFF -DUSE_SYSTEM_FFTW3=ON -DUSE_SYSTEM_HDF5=ON -DUSE_SYSTEM_ACE=ON" PYMVER=2
+   name: py27 -boost +fftw3 +hdf5 +ace +cil_lite
+   env: EXTRA_BUILD_FLAGS="-DUSE_SYSTEM_Boost=OFF -DUSE_SYSTEM_FFTW3=ON -DUSE_SYSTEM_HDF5=ON -DUSE_SYSTEM_ACE=ON -DBUILD_CIL_LITE=ON" PYMVER=2
  - os: linux
    python: 3.6
-   name: py36 -boost +fftw3 +hdf5 +ace
-   env: EXTRA_BUILD_FLAGS="-DUSE_SYSTEM_Boost=OFF -DUSE_SYSTEM_FFTW3=ON -DUSE_SYSTEM_HDF5=ON -DUSE_SYSTEM_ACE=ON" PYMVER=3
+   name: py36 -boost +fftw3 +hdf5 +ace +cil_lite
+   env: EXTRA_BUILD_FLAGS="-DUSE_SYSTEM_Boost=OFF -DUSE_SYSTEM_FFTW3=ON -DUSE_SYSTEM_HDF5=ON -DUSE_SYSTEM_ACE=ON -DBUILD_CIL_LITE=ON" PYMVER=3
  - os: linux
    python: 2.7
    name: py27 -boost +fftw3 +hdf5 +siemens_to_ismrmrd +swig +ace

--- a/version_config.cmake
+++ b/version_config.cmake
@@ -154,6 +154,16 @@ set(DEFAULT_SPM_TAG r7771)
 set(DEFAULT_JSON_URL https://github.com/nlohmann/json.git )
 set(DEFAULT_JSON_TAG v3.7.3)
 
+# CCPi CIL
+set(CIL_VERSION "v19.10")
+set(DEFAULT_CCPi-Framework_URL https://github.com/vais-ral/CCPi-Framework.git)
+set(DEFAULT_CCPi-Framework_TAG ff08216d4e6fef84659b43155c5c52484b1dc543)
+set(DEFAULT_CCPi-Regularisation-Toolkit_URL https://github.com/vais-ral/CCPi-Regularisation-Toolkit.git )
+set(DEFAULT_CCPi-Regularisation-Toolkit_TAG db048a42018857c7aa30033e978a3600cbedb85f)
+set(DEFAULT_CCPi-FrameworkPlugins_URL https://github.com/vais-ral/CCPi-FrameworkPlugins.git)
+set(DEFAULT_CCPi-FrameworkPlugins_TAG "${CIL_VERSION}")
+set(DEFAULT_CCPi-Astra_URL https://github.com/vais-ral/CCPi-Astra.git)
+set(DEFAULT_CCPi-Astra_TAG 8c2493710f5eac1316945585fe6333ab56f9a2a1)
 
 option (DEVEL_BUILD "Developer Build" OFF)
 mark_as_advanced(DEVEL_BUILD)
@@ -181,16 +191,6 @@ if (DEVEL_BUILD)
   set(DEFAULT_ACE_URL https://github.com/paskino/libace-conda)
   set(DEFAULT_ACE_TAG origin/master)
 
-  # CCPi CIL
-  set(DEFAULT_CCPi-Framework_URL https://github.com/vais-ral/CCPi-Framework.git)
-  set(DEFAULT_CCPi-Framework_TAG ff08216d4e6fef84659b43155c5c52484b1dc543)
-  set(DEFAULT_CCPi-Regularisation-Toolkit_URL https://github.com/vais-ral/CCPi-Regularisation-Toolkit.git)
-  set(DEFAULT_CCPi-Regularisation-Toolkit_TAG db048a42018857c7aa30033e978a3600cbedb85f)
-  set(DEFAULT_CCPi-FrameworkPlugins_URL https://github.com/vais-ral/CCPi-FrameworkPlugins.git)
-  set(DEFAULT_CCPi-FrameworkPlugins_TAG origin/master)
-  set(DEFAULT_CCPi-Astra_URL https://github.com/vais-ral/CCPi-Astra.git)
-  set(DEFAULT_CCPi-Astra_TAG 8c2493710f5eac1316945585fe6333ab56f9a2a1)
-
 else()
   set(DEFAULT_SIRF_TAG v2.1.0)
 
@@ -210,16 +210,7 @@ else()
   set(DEFAULT_ACE_URL https://github.com/paskino/libace-conda)
   set(DEFAULT_ACE_TAG origin/master)
   
-  # CCPi CIL
-  set(CIL_VERSION "v19.10")
-  set(DEFAULT_CCPi-Framework_URL https://github.com/vais-ral/CCPi-Framework.git)
-  set(DEFAULT_CCPi-Framework_TAG ff08216d4e6fef84659b43155c5c52484b1dc543)
-  set(DEFAULT_CCPi-Regularisation-Toolkit_URL https://github.com/vais-ral/CCPi-Regularisation-Toolkit.git )
-  set(DEFAULT_CCPi-Regularisation-Toolkit_TAG db048a42018857c7aa30033e978a3600cbedb85f)
-  set(DEFAULT_CCPi-FrameworkPlugins_URL https://github.com/vais-ral/CCPi-FrameworkPlugins.git)
-  set(DEFAULT_CCPi-FrameworkPlugins_TAG "${CIL_VERSION}")
-  set(DEFAULT_CCPi-Astra_URL https://github.com/vais-ral/CCPi-Astra.git)
-  set(DEFAULT_CCPi-Astra_TAG 8c2493710f5eac1316945585fe6333ab56f9a2a1)
+  
 endif()
 
 


### PR DESCRIPTION
closes #304 by removing CIL repos from the `DEVEL_BUILD`. This is due to backward incompatibility of the structure of the CIL package from version 19.10 on.