### PR TITLE
use canonical dir names in swig and fftw for win32

### DIFF
--- a/SuperBuild/External_FFTW3.cmake
+++ b/SuperBuild/External_FFTW3.cmake
@@ -53,6 +53,7 @@ if (WIN32)
     ${${proj}_EP_ARGS}
     URL ${${proj}_URL}
     URL_HASH MD5=${${proj}_MD5}
+    ${${proj}_EP_ARGS_DIRS}
     CONFIGURE_COMMAND ""
     BUILD_COMMAND ""
     INSTALL_COMMAND ${CMAKE_COMMAND} -E make_directory ${${proj}_INSTALL_DIR}

--- a/SuperBuild/External_SWIG.cmake
+++ b/SuperBuild/External_SWIG.cmake
@@ -47,6 +47,7 @@ if(NOT ( DEFINED "USE_SYSTEM_${externalProjName}" AND "${USE_SYSTEM_${externalPr
     ${${proj}_EP_ARGS}
     URL ${${proj}_URL}
     URL_HASH MD5=${${proj}_MD5}
+    ${${proj}_EP_ARGS_DIRS}
     CONFIGURE_COMMAND ""
     BUILD_COMMAND ""
     INSTALL_COMMAND ${CMAKE_COMMAND} -E make_directory ${SWIG_INSTALL_DIR}


### PR DESCRIPTION
closes #16 