### PR TITLE
Fix cil astra

### DIFF
--- a/SuperBuild/External_CIL-ASTRA.cmake
+++ b/SuperBuild/External_CIL-ASTRA.cmake
@@ -1,6 +1,6 @@
 #========================================================================
 # Author: Edoardo Pasca
-# Copyright 2019 UKRI STFC
+# Copyright 2019-2022 UKRI STFC
 #
 # This file is part of the CCP SyneRBI (formerly PETMR) Synergistic Image Reconstruction Framework (SIRF) SuperBuild.
 #
@@ -37,11 +37,6 @@ if(NOT ( DEFINED "USE_SYSTEM_${externalProjName}" AND "${USE_SYSTEM_${externalPr
   SetGitTagAndRepo("${proj}")
 
   ### --- Project specific additions here
-  # set(libcilreg_Install_Dir ${SUPERBUILD_INSTALL_DIR})
-
-  # #message(STATUS "HDF5_ROOT in External_SIRF: " ${HDF5_ROOT})
-  # set(CMAKE_LIBRARY_PATH ${CMAKE_LIBRARY_PATH} ${SUPERBUILD_INSTALL_DIR})
-  # set(CMAKE_INCLUDE_PATH ${CMAKE_INCLUDE_PATH} ${SUPERBUILD_INSTALL_DIR})
 
 
   message("${proj} URL " ${${proj}_URL}  )
@@ -50,6 +45,10 @@ if(NOT ( DEFINED "USE_SYSTEM_${externalProjName}" AND "${USE_SYSTEM_${externalPr
   if("${PYTHON_STRATEGY}" STREQUAL "PYTHONPATH")
     # in case of PYTHONPATH it is sufficient to copy the files to the
     # $PYTHONPATH directory
+    # However, we need to remove some files that are created by the ASTRA install in the source directory
+    # but are neither version-tracked nor git-ignored. Otherwise, an update will fail.
+    # Unfortunately, we rely on internal mechanisms of ExternalProject_Add to use the normal update mechanism.
+    # Maybe there's a better way...
     find_package(Git)
     ExternalProject_Add(${proj}
       ${${proj}_EP_ARGS}


### PR DESCRIPTION
Fixes updates for CIL ASTRA git-failing because an untracked file is in the sources.

Tested on updating SIRF 3.1.0 VM downloaded from [zenodo](https://zenodo.org/record/5035563#.YtRxk7fML50) with the command

```
cd devel/SyneRBI_VM
git fetch --all
git reset --hard
git checkout update_from_superbuild
# clean the SIRF-Exercises.
# if the machine has not been used it's easier to delete the SIRF-Exercises directory
cd ..
rm -rf SIRF-Exercises
.SyneRBI_VM/scripts/update_VM.sh -s -t origin/fix_cil-astra -j 1
```

This updates SIRF to 3.3.0 (master). 

Still it doesn't update CIL, for instance, but it does rebuild ISMRMRD to 1.7 with support for the utilities, thereby fixing #745 