### PR TITLE
bump sirf.contrib

### DIFF
--- a/SuperBuild/External_SIRF-Contribs.cmake
+++ b/SuperBuild/External_SIRF-Contribs.cmake
@@ -18,7 +18,6 @@
 # limitations under the License.
 #
 #=========================================================================
-
 #This needs to be unique globally
 set(proj SIRF-Contribs)
 
@@ -43,10 +42,10 @@ if(NOT ( DEFINED "USE_SYSTEM_${externalProjName}" AND "${USE_SYSTEM_${externalPr
         ${${proj}_EP_ARGS}
         ${${proj}_EP_ARGS_GIT}
         ${${proj}_EP_ARGS_DIRS}
-
+        UPDATE_COMMAND ""
         CONFIGURE_COMMAND ""
         BUILD_COMMAND ""
-        INSTALL_COMMAND ${CMAKE_COMMAND} -E copy_directory ${${proj}_SOURCE_DIR}/src/Python/sirf/ ${PYTHON_DEST}/sirf
+        INSTALL_COMMAND ${CMAKE_COMMAND} -E env ${Python_EXECUTABLE} -m pip install ${${proj}_SOURCE_DIR}
       )
     else()
       # if SETUP_PY one can launch the conda build.sh script setting 

--- a/version_config.cmake
+++ b/version_config.cmake
@@ -144,7 +144,7 @@ set(DEFAULT_STIR_TAG rel_6.3.0)
 
 ## SIRF
 set(DEFAULT_SIRF_URL https://github.com/SyneRBI/SIRF)
-set(DEFAULT_SIRF_TAG "0ba22c9b5d8b6c2f008e0b1e1846c059703a88c3") # 2025-11-03
+set(DEFAULT_SIRF_TAG "11a6a50fc13bf52439d0c1ec15ebacfbadada8c5") # 2026-01-29
 
 ## pet-rd-tools
 set(DEFAULT_pet_rd_tools_URL https://github.com/UCL/pet-rd-tools)
@@ -152,7 +152,7 @@ set(DEFAULT_pet_rd_tools_TAG v2.0.2)
 
 ## SIRF-Contribs
 set(DEFAULT_SIRF-Contribs_URL https://github.com/SyneRBI/SIRF-Contribs)
-set(DEFAULT_SIRF-Contribs_TAG v3.9.0)
+set(DEFAULT_SIRF-Contribs_TAG "d62593f98c966b601f660808247a682757f80e3c") # 2026-01-29
 
 ## SPM
 set(DEFAULT_SPM_URL https://github.com/spm/SPM12)


### PR DESCRIPTION
- update `External_SIRF-Contribs.cmake` to use `pip install` (fixes #981)
  + includes `sirf.contrib.MaGeZ.ALG1` required by https://github.com/SyneRBI/PETRIC2/pull/54
  + [x] depends on https://github.com/SyneRBI/SIRF-Contribs/pull/29
  + [x] depends on https://github.com/SyneRBI/SIRF/pull/1371
  + partially fixes #920
