### PR TITLE
bump tomophantom

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -4,7 +4,7 @@ on:
     branches: [master]
     paths-ignore:
     - 'docker/Dockerfile'
-    - 'docker/*yml'
+    - 'docker/docker*.yml'
     - '**.md'
     - 'VirtualBox/**'
     - '.github/workflows/*docker*'
@@ -16,7 +16,7 @@ on:
     branches: [master]
     paths-ignore:
     - 'docker/Dockerfile'
-    - 'docker/*yml'
+    - 'docker/docker*.yml'
     - '**.md'
     - 'VirtualBox/**'
     - '.github/workflows/*docker*'

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,10 +3,11 @@
 ## v3.X.x
 - CMake:
   - Patch ISMRMRD `CMAKE_INSTALL_RPATH_USE_LINK_PATH` (#991)
+  - CCPi-Regularisation-Toolkit, astra-toolbox, TomoPhantom: moved to conda
 - Updated versions:
   - SIRF-Contribs: v3.9.1
   - SIRF: 6e429c2d1862057086720c543d220730feb3eecb (2026-05-12)
-  - CCPi-Regularisation-Toolkit, astra-toolbox, TomoPhantom: moved to conda
+  - TomoPhantom: 3.1.4
 
 ## v3.9.0
 - VM: set the matplotlib backend to tkagg

--- a/docker/requirements.yml
+++ b/docker/requirements.yml
@@ -33,7 +33,7 @@ dependencies:
   - ipp-include =2021.12.* # cil
   - ccpi-regulariser >=25  # cil
   - cil-data >=22          # cil
-  - ccpi::tomophantom    # cil
+  - httomo::tomophantom >=3.1.4 # cil
   - ccpi::dxchange >=0.2.1 # cil
   - h5py           # cil
   - numba          # cil


### PR DESCRIPTION
- reverts to upstream conda package due to https://github.com/dkazanc/TomoPhantom/pull/139
  + [x] depends on https://github.com/dkazanc/TomoPhantom/pull/140
- CI: run `c-cpp` on `requirements.yml` change (follow-up to #994)