### PR TITLE
llvm-openmp to fix CIL runtime error, misc housekeeping

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -75,7 +75,7 @@ jobs:
       name: install dependencies
       working-directory: docker
       run: |
-        mamba env update -n base -f requirements.yml
+        conda env update -n base -f requirements.yml
         echo "Python_ROOT_DIR=$CONDA_PREFIX" >> $GITHUB_ENV
         echo "Python3_ROOT_DIR=$CONDA_PREFIX" >> $GITHUB_ENV
         sudo ./raw-ubuntu.sh

--- a/SuperBuild.cmake
+++ b/SuperBuild.cmake
@@ -208,6 +208,8 @@ if (NOT DISABLE_OpenMP)
   find_package(OpenMP)
   if (OPENMP_FOUND)
      message(STATUS "OpenMP found, support enabled. If you get compiler errors saying \"omp.h not found\", set the following CMake variables: OpenMP_CXX_INCLUDE_DIR, OpenMP_C_INCLUDE_DIR. For linking errors, check other \"OpenMP\*\" CMake variables as well.")
+     message(STATUS "OpenMP_CXX_INCLUDE_DIR: ${OpenMP_CXX_INCLUDE_DIR}")
+     message(STATUS "OpenMP_CXX_LIB_NAMES: ${OpenMP_CXX_LIB_NAMES}")
 
     mark_as_superbuild(ALL_PROJECTS VARS
       OpenMP_CXX_FLAGS:STRING OpenMP_C_FLAGS:STRING

--- a/docker/requirements.yml
+++ b/docker/requirements.yml
@@ -24,7 +24,7 @@ dependencies:
   - jupytext
   - tensorboard
   - tensorboardx
-  - libgomp # parallelproj
+  - llvm-openmp
   - jupyterlab_widgets
   - ipywidgets >=8
   - ipympl

--- a/docker/requirements.yml
+++ b/docker/requirements.yml
@@ -25,6 +25,9 @@ dependencies:
   - tensorboard
   - tensorboardx
   - libgomp # parallelproj
+  - jupyterlab_widgets
+  - ipywidgets >=8
+  - ipympl
   # - ccpi/label/dev::tigre # cil (GPU)
   # - astra-toolbox::astra-toolbox 2.* # cil (GPU)
   # - cuda-version 12.8.* # cil (GPU)
@@ -45,11 +48,4 @@ dependencies:
   - pip
   - pip:
     - git+https://github.com/ismrmrd/ismrmrd-python-tools.git@master#egg=ismrmrd-python-tools
-    # TODO: labextension @jupyter-widgets/jupyterlab-manager (jupyterlab_widgets ipywidgets ipympl)
-    # is broken because `conda-forge::cil` downgrades `ipywidgets<8` -> breaks `%matplotlib widgets`.
-    # - temp fix: install upgraded versions via pip (not conda)
-    # - proper fix: remove after https://github.com/TomographicImaging/CIL/issues/1600
-    - jupyterlab_widgets
-    - ipywidgets>=8
-    - ipympl
     - unittest-parametrize # cil


### PR DESCRIPTION
Three unrelated items; can't be bothered to split into separate PRs:

1. **mamba error** (info below) CI: use `conda` instead of `mamba`
2. deps (housekeeping): move `ipywidgets` dependencies from `pip` to `conda` due to https://github.com/TomographicImaging/CIL/issues/1600 being resolved
3. deps (bugfix): use `llvm-openmp` (instead of nothing or `libgomp`) to fix CIL runtime error ([no idea why](https://github.com/SyneRBI/SIRF-SuperBuild/pull/996#issuecomment-4485736315))

## 1. mamba error

Comparing [-passing](https://github.com/SyneRBI/SIRF-SuperBuild/actions/runs/25919844427/job/76493109354) to [+failing](https://github.com/SyneRBI/SIRF-SuperBuild/actions/runs/25919844427/job/76493108948):

```diff
 Image: ubuntu-22.04
-Version: 20260413.88.1
+Version: 20260513.139.2
...
 Downgrade:
 - _openmp_mutex                                 5.1  1_gnu                     pkgs/main
 + _openmp_mutex                                 4.5  7_kmp_llvm                conda-forge
+- libarchive                                   3.8.7  hb3cce40_0               pkgs/main
++ libarchive                                   3.8.6  gpl_hc2c16d8_100         conda-forge
+- libmamba                                     2.6.1  hd28c85e_0               conda-forge
++ libmamba                                     2.5.0  hd28c85e_0               conda-forge
+- libmamba-spdlog                              2.6.1  hd8d719e_0               conda-forge
++ libmamba-spdlog                              2.5.0  h12fcf84_0               conda-forge
+- libmambapy                                   2.6.1  py313h842faf6_0          conda-forge
++ libmambapy                                   2.5.0  py313h4616538_0          conda-forge
+- mamba                                        2.6.1  h2a27def_0               conda-forge
++ mamba                                        2.5.0  h9835478_0               conda-forge
+- simdjson                                     4.6.4  hb700be7_0               conda-forge
++ simdjson                                     4.2.4  hb700be7_0               conda-forge
 Summary:
 Install: 277 packages
-Change: 3 packages
-Upgrade: 8 packages
-Downgrade: 1 packages
+Change: 2 packages
+Upgrade: 5 packages
+Downgrade: 7 packages
...
+/tmp/mambafylm1mdqvkn: line 2: /usr/share/miniconda/bin/mamba (deleted): No such file or directory
+/tmp/mambafylm1mdqvkn: line 3: syntax error near unexpected token `deleted'
+/tmp/mambafylm1mdqvkn: line 3: `mamba (deleted) activate "/usr/share/miniconda"'
```

So somehow `mamba` is being downgraded `2.6.1` -> `2.5.0` causing failures.