### PR TITLE
docker GPU updates

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -19,6 +19,8 @@
   - SIRF: 6e429c2d1862057086720c543d220730feb3eecb (2026-05-12)
   - STIR: 6.4.0
   - TomoPhantom: 3.1.4
+  - TIGRE: 3.1.3
+  - CUDA: 12.9.2
 
 ## v3.9.0
 - VM: set the matplotlib backend to tkagg

--- a/docker/docker-compose.gpu.yml
+++ b/docker/docker-compose.gpu.yml
@@ -3,7 +3,7 @@ services:
   image: synerbi/jupyter:foundation-gpu
   build:
    args:
-    ROOT_IMAGE: nvidia/cuda:12.8.1-cudnn-devel-ubuntu22.04
+    ROOT_IMAGE: nvidia/cuda:12.9.2-cudnn-devel-ubuntu22.04
     PYTHON_VERSION: 3.12
  base:
   image: synerbi/jupyter:base-gpu

--- a/docker/requirements.yml
+++ b/docker/requirements.yml
@@ -29,12 +29,12 @@ dependencies:
   - jupyterlab_widgets
   - ipywidgets >=8
   - ipympl
-  # - ccpi::tigre >=3.1.3 # cil (GPU)
-  # - astra-toolbox::astra-toolbox 2.* # cil (GPU)
-  # - cuda-version 12.8.* # cil (GPU)
-  - ipp =2021.12.*         # cil
-  - ipp-devel =2021.12.*   # cil
-  - ipp-include =2021.12.* # cil
+  # - ccpi::tigre >=3.1.3  # cil (GPU)
+  # - astra-toolbox::astra-toolbox 2  # cil (GPU)
+  # - cuda-version 12.9.*  # cil (GPU)
+  - ipp =2021.12           # cil
+  - ipp-devel =2021.12     # cil
+  - ipp-include =2021.12   # cil
   - ccpi-regulariser >=25  # cil
   - cil-data >=22          # cil
   - httomo::tomophantom >=3.1.4 # cil

--- a/docker/requirements.yml
+++ b/docker/requirements.yml
@@ -30,13 +30,13 @@ dependencies:
   - ipywidgets >=8
   - ipympl
   # - ccpi::tigre >=3.1.3  # cil (GPU)
-  # - astra-toolbox::astra-toolbox 2  # cil (GPU)
   # - cuda-version 12.9.*  # cil (GPU)
-  - ipp =2021.12           # cil
-  - ipp-devel =2021.12     # cil
-  - ipp-include =2021.12   # cil
+  - ipp =2021.12.*         # cil
+  - ipp-devel =2021.12.*   # cil
+  - ipp-include =2021.12.* # cil
   - ccpi-regulariser >=25  # cil
   - cil-data >=22          # cil
+  - astra-toolbox::astra-toolbox 2.* # cil
   - httomo::tomophantom >=3.1.4 # cil
   - ccpi::dxchange >=0.2.1 # cil
   - h5py           # cil

--- a/docker/requirements.yml
+++ b/docker/requirements.yml
@@ -29,7 +29,7 @@ dependencies:
   - jupyterlab_widgets
   - ipywidgets >=8
   - ipympl
-  # - ccpi/label/dev::tigre # cil (GPU)
+  # - ccpi::tigre >=3.1.3 # cil (GPU)
   # - astra-toolbox::astra-toolbox 2.* # cil (GPU)
   # - cuda-version 12.8.* # cil (GPU)
   - ipp =2021.12.*         # cil

--- a/docker/user_demos.sh
+++ b/docker/user_demos.sh
@@ -22,7 +22,7 @@ if [ "$PYTHON" = "miniconda" ]; then
       sed -r 's/^(\s*)#\s*(- \S+.*#.*GPU.*)$/\1\2/' environment.yml > environment-sirf.yml
     else
       # delete GPU deps
-      sed -r -e '/^\s*- (astra-toolbox|tigre).*/d' -e '/^\s*- \S+.*#.*GPU/d' environment.yml > environment-sirf.yml
+      sed -r '/- (.*astra-toolbox|.*tigre|\S+.*#.*GPU).*/d' environment.yml > environment-sirf.yml
     fi
     echo "delete CIL, CCP-Regulariser packages from the environment file"
     sed -r -i -e '/^\s*- (cil|ccpi-regulariser).*/d' environment-sirf.yml

--- a/docker/user_demos.sh
+++ b/docker/user_demos.sh
@@ -22,7 +22,7 @@ if [ "$PYTHON" = "miniconda" ]; then
       sed -r 's/^(\s*)#\s*(- \S+.*#.*GPU.*)$/\1\2/' environment.yml > environment-sirf.yml
     else
       # delete GPU deps
-      sed -r '/- (.*astra-toolbox|.*tigre|\S+.*#.*GPU).*/d' environment.yml > environment-sirf.yml
+      sed -r '/- (.*tigre|\S+.*#.*GPU).*/d' environment.yml > environment-sirf.yml
     fi
     echo "delete CIL, CCP-Regulariser packages from the environment file"
     sed -r -i -e '/^\s*- (cil|ccpi-regulariser).*/d' environment-sirf.yml


### PR DESCRIPTION
- bump `ccpi/label/dev::tigre` -> `ccpi::tigre>=3.1.3`
  + bump CUDA `12.8.1` -> `13.1.1`
- bump `astra-toolbox::astra-toolbox 2.*` for both CPU & GPU
- [x] ~depends on https://github.com/TomographicImaging/TIGRE-conda/pull/26~
