### PR TITLE
bump parallelproj

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -19,6 +19,7 @@
   - SIRF: 6e429c2d1862057086720c543d220730feb3eecb (2026-05-12)
   - STIR: 6.4.0
   - TomoPhantom: 3.1.4
+  - parallelproj: 2.0.5
 
 ## v3.9.0
 - VM: set the matplotlib backend to tkagg

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -20,6 +20,7 @@
   - STIR: 6.4.0
   - TomoPhantom: 3.1.4
   - parallelproj: 2.0.5
+  - CMake: 3.31.12
 
 ## v3.9.0
 - VM: set the matplotlib backend to tkagg

--- a/VirtualBox/scripts/INSTALL_CMake.sh
+++ b/VirtualBox/scripts/INSTALL_CMake.sh
@@ -16,7 +16,7 @@ else
     INSTALL_LOC=$1
 fi
 # default version, but can be set externally
-: ${ver=3.29.6}
+: ${ver=3.31.12}
 
 echo "Downloading CMake $ver in /tmp"
 cd /tmp

--- a/docker/build_essential-ubuntu.sh
+++ b/docker/build_essential-ubuntu.sh
@@ -20,7 +20,7 @@ apt-get clean
 pushd $INSTALL_DIR
 
 # CMake
-curl -o cmake.tgz -L https://github.com/Kitware/CMake/releases/download/v3.29.6/cmake-3.29.6-linux-x86_64.tar.gz
+curl -o cmake.tgz -L https://github.com/Kitware/CMake/releases/download/v3.31.12/cmake-3.31.12-linux-x86_64.tar.gz
 mkdir -p /usr/local
 pushd /usr/local
 tar xzf $INSTALL_DIR/cmake.tgz --strip 1

--- a/version_config.cmake
+++ b/version_config.cmake
@@ -126,8 +126,8 @@ set(DEFAULT_NiftyPET_URL https://github.com/pjmark/NIPET)
 set(DEFAULT_NiftyPET_TAG 70b97da0a4eea9445e34831f7393947a37bc77e7)
 
 ## parallelproj
-set(DEFAULT_parallelproj_URL https://github.com/gschramm/parallelproj)
-set(DEFAULT_parallelproj_TAG v1.10.2)
+set(DEFAULT_parallelproj_URL https://github.com/KUL-recon-lab/libparallelproj)
+set(DEFAULT_parallelproj_TAG v2.0.5)
 
 ## STIR
 # SIRF might work with STIR 6.3.0, but that version has a bug


### PR DESCRIPTION
- update libparallelproj URL & version [gschramm/parallelproj@v1.10.2](https://github.com/KUL-recon-lab/parallelproj/releases/tag/v1.10.2) ->
[KUL-recon-lab/libparallelproj@v2.0.5](https://github.com/KUL-recon-lab/libparallelproj/releases/tag/v2.0.5) (fixes #998)
  + bump CMake `3.29.6` -> `3.31.12`